### PR TITLE
(BROKEN) Added a SWIFT Sample - RBQFetchedResultsControllerSwiftExample

### DIFF
--- a/RBQFetchedResultsControllerSwiftExample/Podfile
+++ b/RBQFetchedResultsControllerSwiftExample/Podfile
@@ -1,0 +1,12 @@
+source 'https://github.com/CocoaPods/Specs.git'
+use_frameworks!
+platform :ios, '8.0'
+
+target 'RBQFetchedResultsControllerSwiftExample' do
+    pod 'Realm'
+    pod 'RBQFetchedResultsController'
+end
+
+target 'RBQFetchedResultsControllerSwiftExampleTests' do
+    pod 'Realm/Headers'
+end

--- a/RBQFetchedResultsControllerSwiftExample/RBQFetchedResultsControllerSwiftExample.xcodeproj/project.pbxproj
+++ b/RBQFetchedResultsControllerSwiftExample/RBQFetchedResultsControllerSwiftExample.xcodeproj/project.pbxproj
@@ -1,0 +1,571 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		0CDC6B32E075B97FD285505C /* Pods_RBQFetchedResultsControllerSwiftExampleTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 487C24250B439F663220708A /* Pods_RBQFetchedResultsControllerSwiftExampleTests.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		A05F2E211ACE13A50071A5EA /* RLMSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A05F2E201ACE13A50071A5EA /* RLMSupport.swift */; };
+		A0C6AA421ACDF7F700362B91 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0C6AA411ACDF7F700362B91 /* AppDelegate.swift */; };
+		A0C6AA441ACDF7F700362B91 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0C6AA431ACDF7F700362B91 /* ViewController.swift */; };
+		A0C6AA471ACDF7F700362B91 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A0C6AA451ACDF7F700362B91 /* Main.storyboard */; };
+		A0C6AA491ACDF7F700362B91 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A0C6AA481ACDF7F700362B91 /* Images.xcassets */; };
+		A0C6AA4C1ACDF7F700362B91 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = A0C6AA4A1ACDF7F700362B91 /* LaunchScreen.xib */; };
+		A0C6AA581ACDF7F800362B91 /* RBQFetchedResultsControllerSwiftExampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0C6AA571ACDF7F800362B91 /* RBQFetchedResultsControllerSwiftExampleTests.swift */; };
+		A0C6AA621ACDFB0E00362B91 /* ExampleTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0C6AA611ACDFB0E00362B91 /* ExampleTableViewController.swift */; };
+		A0C6AA641ACDFCB800362B91 /* TestObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0C6AA631ACDFCB800362B91 /* TestObject.swift */; };
+		B6FEF20812AD428D4E374A45 /* Pods_RBQFetchedResultsControllerSwiftExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DEF571F803F779202544F35 /* Pods_RBQFetchedResultsControllerSwiftExample.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		A0C6AA521ACDF7F800362B91 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A0C6AA341ACDF7F700362B91 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A0C6AA3B1ACDF7F700362B91;
+			remoteInfo = RBQFetchedResultsControllerSwiftExample;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		1DEF571F803F779202544F35 /* Pods_RBQFetchedResultsControllerSwiftExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RBQFetchedResultsControllerSwiftExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		254D5A92BB1D4F1917793393 /* Pods-RBQFetchedResultsControllerSwiftExampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RBQFetchedResultsControllerSwiftExampleTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-RBQFetchedResultsControllerSwiftExampleTests/Pods-RBQFetchedResultsControllerSwiftExampleTests.debug.xcconfig"; sourceTree = "<group>"; };
+		487C24250B439F663220708A /* Pods_RBQFetchedResultsControllerSwiftExampleTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RBQFetchedResultsControllerSwiftExampleTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		607C1E5673E03323005C3A45 /* Pods-RBQFetchedResultsControllerSwiftExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RBQFetchedResultsControllerSwiftExample.release.xcconfig"; path = "Pods/Target Support Files/Pods-RBQFetchedResultsControllerSwiftExample/Pods-RBQFetchedResultsControllerSwiftExample.release.xcconfig"; sourceTree = "<group>"; };
+		836741F956AF0B411DCFA5B2 /* Pods-RBQFetchedResultsControllerSwiftExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RBQFetchedResultsControllerSwiftExample.debug.xcconfig"; path = "Pods/Target Support Files/Pods-RBQFetchedResultsControllerSwiftExample/Pods-RBQFetchedResultsControllerSwiftExample.debug.xcconfig"; sourceTree = "<group>"; };
+		84419445E08280ABFFD71631 /* Pods-RBQFetchedResultsControllerSwiftExampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RBQFetchedResultsControllerSwiftExampleTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-RBQFetchedResultsControllerSwiftExampleTests/Pods-RBQFetchedResultsControllerSwiftExampleTests.release.xcconfig"; sourceTree = "<group>"; };
+		A05F2E201ACE13A50071A5EA /* RLMSupport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RLMSupport.swift; sourceTree = "<group>"; };
+		A0C6AA3C1ACDF7F700362B91 /* RBQFetchedResultsControllerSwiftExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RBQFetchedResultsControllerSwiftExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		A0C6AA401ACDF7F700362B91 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A0C6AA411ACDF7F700362B91 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		A0C6AA431ACDF7F700362B91 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		A0C6AA461ACDF7F700362B91 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		A0C6AA481ACDF7F700362B91 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
+		A0C6AA4B1ACDF7F700362B91 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
+		A0C6AA511ACDF7F800362B91 /* RBQFetchedResultsControllerSwiftExampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RBQFetchedResultsControllerSwiftExampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		A0C6AA561ACDF7F800362B91 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A0C6AA571ACDF7F800362B91 /* RBQFetchedResultsControllerSwiftExampleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RBQFetchedResultsControllerSwiftExampleTests.swift; sourceTree = "<group>"; };
+		A0C6AA611ACDFB0E00362B91 /* ExampleTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExampleTableViewController.swift; sourceTree = "<group>"; };
+		A0C6AA631ACDFCB800362B91 /* TestObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestObject.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		A0C6AA391ACDF7F700362B91 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B6FEF20812AD428D4E374A45 /* Pods_RBQFetchedResultsControllerSwiftExample.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A0C6AA4E1ACDF7F800362B91 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0CDC6B32E075B97FD285505C /* Pods_RBQFetchedResultsControllerSwiftExampleTests.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		4AF03A2EB9A71620E60567D5 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				1DEF571F803F779202544F35 /* Pods_RBQFetchedResultsControllerSwiftExample.framework */,
+				487C24250B439F663220708A /* Pods_RBQFetchedResultsControllerSwiftExampleTests.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		6A56513339E21DDC76B4DE04 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				836741F956AF0B411DCFA5B2 /* Pods-RBQFetchedResultsControllerSwiftExample.debug.xcconfig */,
+				607C1E5673E03323005C3A45 /* Pods-RBQFetchedResultsControllerSwiftExample.release.xcconfig */,
+				254D5A92BB1D4F1917793393 /* Pods-RBQFetchedResultsControllerSwiftExampleTests.debug.xcconfig */,
+				84419445E08280ABFFD71631 /* Pods-RBQFetchedResultsControllerSwiftExampleTests.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+		A0C6AA331ACDF7F700362B91 = {
+			isa = PBXGroup;
+			children = (
+				A0C6AA3E1ACDF7F700362B91 /* RBQFetchedResultsControllerSwiftExample */,
+				A0C6AA541ACDF7F800362B91 /* RBQFetchedResultsControllerSwiftExampleTests */,
+				A0C6AA3D1ACDF7F700362B91 /* Products */,
+				6A56513339E21DDC76B4DE04 /* Pods */,
+				4AF03A2EB9A71620E60567D5 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		A0C6AA3D1ACDF7F700362B91 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				A0C6AA3C1ACDF7F700362B91 /* RBQFetchedResultsControllerSwiftExample.app */,
+				A0C6AA511ACDF7F800362B91 /* RBQFetchedResultsControllerSwiftExampleTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		A0C6AA3E1ACDF7F700362B91 /* RBQFetchedResultsControllerSwiftExample */ = {
+			isa = PBXGroup;
+			children = (
+				A05F2E201ACE13A50071A5EA /* RLMSupport.swift */,
+				A0C6AA411ACDF7F700362B91 /* AppDelegate.swift */,
+				A0C6AA431ACDF7F700362B91 /* ViewController.swift */,
+				A0C6AA611ACDFB0E00362B91 /* ExampleTableViewController.swift */,
+				A0C6AA451ACDF7F700362B91 /* Main.storyboard */,
+				A0C6AA481ACDF7F700362B91 /* Images.xcassets */,
+				A0C6AA4A1ACDF7F700362B91 /* LaunchScreen.xib */,
+				A0C6AA631ACDFCB800362B91 /* TestObject.swift */,
+				A0C6AA3F1ACDF7F700362B91 /* Supporting Files */,
+			);
+			path = RBQFetchedResultsControllerSwiftExample;
+			sourceTree = "<group>";
+		};
+		A0C6AA3F1ACDF7F700362B91 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				A0C6AA401ACDF7F700362B91 /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		A0C6AA541ACDF7F800362B91 /* RBQFetchedResultsControllerSwiftExampleTests */ = {
+			isa = PBXGroup;
+			children = (
+				A0C6AA571ACDF7F800362B91 /* RBQFetchedResultsControllerSwiftExampleTests.swift */,
+				A0C6AA551ACDF7F800362B91 /* Supporting Files */,
+			);
+			path = RBQFetchedResultsControllerSwiftExampleTests;
+			sourceTree = "<group>";
+		};
+		A0C6AA551ACDF7F800362B91 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				A0C6AA561ACDF7F800362B91 /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		A0C6AA3B1ACDF7F700362B91 /* RBQFetchedResultsControllerSwiftExample */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A0C6AA5B1ACDF7F800362B91 /* Build configuration list for PBXNativeTarget "RBQFetchedResultsControllerSwiftExample" */;
+			buildPhases = (
+				42F0813F989E65F01320714E /* Check Pods Manifest.lock */,
+				A0C6AA381ACDF7F700362B91 /* Sources */,
+				A0C6AA391ACDF7F700362B91 /* Frameworks */,
+				A0C6AA3A1ACDF7F700362B91 /* Resources */,
+				3A322FA750E6DAF0DF23862D /* Copy Pods Resources */,
+				1857BFF52BA27D029A9C9779 /* Embed Pods Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = RBQFetchedResultsControllerSwiftExample;
+			productName = RBQFetchedResultsControllerSwiftExample;
+			productReference = A0C6AA3C1ACDF7F700362B91 /* RBQFetchedResultsControllerSwiftExample.app */;
+			productType = "com.apple.product-type.application";
+		};
+		A0C6AA501ACDF7F800362B91 /* RBQFetchedResultsControllerSwiftExampleTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A0C6AA5E1ACDF7F800362B91 /* Build configuration list for PBXNativeTarget "RBQFetchedResultsControllerSwiftExampleTests" */;
+			buildPhases = (
+				5CA52D63092B5BDDE0839CD6 /* Check Pods Manifest.lock */,
+				A0C6AA4D1ACDF7F800362B91 /* Sources */,
+				A0C6AA4E1ACDF7F800362B91 /* Frameworks */,
+				A0C6AA4F1ACDF7F800362B91 /* Resources */,
+				2727389B3966A8CF9944F3EE /* Copy Pods Resources */,
+				1993D2CAC8D1B41BD220E7D5 /* Embed Pods Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A0C6AA531ACDF7F800362B91 /* PBXTargetDependency */,
+			);
+			name = RBQFetchedResultsControllerSwiftExampleTests;
+			productName = RBQFetchedResultsControllerSwiftExampleTests;
+			productReference = A0C6AA511ACDF7F800362B91 /* RBQFetchedResultsControllerSwiftExampleTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		A0C6AA341ACDF7F700362B91 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0620;
+				ORGANIZATIONNAME = Jeff;
+				TargetAttributes = {
+					A0C6AA3B1ACDF7F700362B91 = {
+						CreatedOnToolsVersion = 6.2;
+					};
+					A0C6AA501ACDF7F800362B91 = {
+						CreatedOnToolsVersion = 6.2;
+						TestTargetID = A0C6AA3B1ACDF7F700362B91;
+					};
+				};
+			};
+			buildConfigurationList = A0C6AA371ACDF7F700362B91 /* Build configuration list for PBXProject "RBQFetchedResultsControllerSwiftExample" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = A0C6AA331ACDF7F700362B91;
+			productRefGroup = A0C6AA3D1ACDF7F700362B91 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				A0C6AA3B1ACDF7F700362B91 /* RBQFetchedResultsControllerSwiftExample */,
+				A0C6AA501ACDF7F800362B91 /* RBQFetchedResultsControllerSwiftExampleTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		A0C6AA3A1ACDF7F700362B91 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A0C6AA471ACDF7F700362B91 /* Main.storyboard in Resources */,
+				A0C6AA4C1ACDF7F700362B91 /* LaunchScreen.xib in Resources */,
+				A0C6AA491ACDF7F700362B91 /* Images.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A0C6AA4F1ACDF7F800362B91 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		1857BFF52BA27D029A9C9779 /* Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-RBQFetchedResultsControllerSwiftExample/Pods-RBQFetchedResultsControllerSwiftExample-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		1993D2CAC8D1B41BD220E7D5 /* Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-RBQFetchedResultsControllerSwiftExampleTests/Pods-RBQFetchedResultsControllerSwiftExampleTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		2727389B3966A8CF9944F3EE /* Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-RBQFetchedResultsControllerSwiftExampleTests/Pods-RBQFetchedResultsControllerSwiftExampleTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		3A322FA750E6DAF0DF23862D /* Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-RBQFetchedResultsControllerSwiftExample/Pods-RBQFetchedResultsControllerSwiftExample-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		42F0813F989E65F01320714E /* Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		5CA52D63092B5BDDE0839CD6 /* Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		A0C6AA381ACDF7F700362B91 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A0C6AA621ACDFB0E00362B91 /* ExampleTableViewController.swift in Sources */,
+				A0C6AA441ACDF7F700362B91 /* ViewController.swift in Sources */,
+				A05F2E211ACE13A50071A5EA /* RLMSupport.swift in Sources */,
+				A0C6AA641ACDFCB800362B91 /* TestObject.swift in Sources */,
+				A0C6AA421ACDF7F700362B91 /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A0C6AA4D1ACDF7F800362B91 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A0C6AA581ACDF7F800362B91 /* RBQFetchedResultsControllerSwiftExampleTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		A0C6AA531ACDF7F800362B91 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A0C6AA3B1ACDF7F700362B91 /* RBQFetchedResultsControllerSwiftExample */;
+			targetProxy = A0C6AA521ACDF7F800362B91 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		A0C6AA451ACDF7F700362B91 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				A0C6AA461ACDF7F700362B91 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		A0C6AA4A1ACDF7F700362B91 /* LaunchScreen.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				A0C6AA4B1ACDF7F700362B91 /* Base */,
+			);
+			name = LaunchScreen.xib;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		A0C6AA591ACDF7F800362B91 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		A0C6AA5A1ACDF7F800362B91 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		A0C6AA5C1ACDF7F800362B91 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 836741F956AF0B411DCFA5B2 /* Pods-RBQFetchedResultsControllerSwiftExample.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				INFOPLIST_FILE = RBQFetchedResultsControllerSwiftExample/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		A0C6AA5D1ACDF7F800362B91 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 607C1E5673E03323005C3A45 /* Pods-RBQFetchedResultsControllerSwiftExample.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				INFOPLIST_FILE = RBQFetchedResultsControllerSwiftExample/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		A0C6AA5F1ACDF7F800362B91 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 254D5A92BB1D4F1917793393 /* Pods-RBQFetchedResultsControllerSwiftExampleTests.debug.xcconfig */;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = RBQFetchedResultsControllerSwiftExampleTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/RBQFetchedResultsControllerSwiftExample.app/RBQFetchedResultsControllerSwiftExample";
+			};
+			name = Debug;
+		};
+		A0C6AA601ACDF7F800362B91 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 84419445E08280ABFFD71631 /* Pods-RBQFetchedResultsControllerSwiftExampleTests.release.xcconfig */;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = RBQFetchedResultsControllerSwiftExampleTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/RBQFetchedResultsControllerSwiftExample.app/RBQFetchedResultsControllerSwiftExample";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		A0C6AA371ACDF7F700362B91 /* Build configuration list for PBXProject "RBQFetchedResultsControllerSwiftExample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A0C6AA591ACDF7F800362B91 /* Debug */,
+				A0C6AA5A1ACDF7F800362B91 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A0C6AA5B1ACDF7F800362B91 /* Build configuration list for PBXNativeTarget "RBQFetchedResultsControllerSwiftExample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A0C6AA5C1ACDF7F800362B91 /* Debug */,
+				A0C6AA5D1ACDF7F800362B91 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A0C6AA5E1ACDF7F800362B91 /* Build configuration list for PBXNativeTarget "RBQFetchedResultsControllerSwiftExampleTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A0C6AA5F1ACDF7F800362B91 /* Debug */,
+				A0C6AA601ACDF7F800362B91 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = A0C6AA341ACDF7F700362B91 /* Project object */;
+}

--- a/RBQFetchedResultsControllerSwiftExample/RBQFetchedResultsControllerSwiftExample/AppDelegate.swift
+++ b/RBQFetchedResultsControllerSwiftExample/RBQFetchedResultsControllerSwiftExample/AppDelegate.swift
@@ -1,0 +1,46 @@
+//
+//  AppDelegate.swift
+//  RBQFetchedResultsControllerSwiftExample
+//
+//  Created by Jeff on 4/2/15.
+//  Copyright (c) 2015 Jeff. All rights reserved.
+//
+
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    var window: UIWindow?
+
+
+    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    func applicationWillResignActive(application: UIApplication) {
+        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+        // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
+    }
+
+    func applicationDidEnterBackground(application: UIApplication) {
+        // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
+        // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+    }
+
+    func applicationWillEnterForeground(application: UIApplication) {
+        // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
+    }
+
+    func applicationDidBecomeActive(application: UIApplication) {
+        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+    }
+
+    func applicationWillTerminate(application: UIApplication) {
+        // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+    }
+
+
+}
+

--- a/RBQFetchedResultsControllerSwiftExample/RBQFetchedResultsControllerSwiftExample/Base.lproj/LaunchScreen.xib
+++ b/RBQFetchedResultsControllerSwiftExample/RBQFetchedResultsControllerSwiftExample/Base.lproj/LaunchScreen.xib
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6214" systemVersion="14A314h" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6207"/>
+        <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="480"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  Copyright (c) 2015 Jeff. All rights reserved." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="8ie-xW-0ye">
+                    <rect key="frame" x="20" y="439" width="441" height="21"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="RBQFetchedResultsControllerSwiftExample" textAlignment="center" lineBreakMode="middleTruncation" baselineAdjustment="alignBaselines" minimumFontSize="18" translatesAutoresizingMaskIntoConstraints="NO" id="kId-c2-rCX">
+                    <rect key="frame" x="20" y="140" width="441" height="43"/>
+                    <fontDescription key="fontDescription" type="boldSystem" pointSize="36"/>
+                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <constraints>
+                <constraint firstItem="kId-c2-rCX" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="bottom" multiplier="1/3" constant="1" id="5cJ-9S-tgC"/>
+                <constraint firstAttribute="centerX" secondItem="kId-c2-rCX" secondAttribute="centerX" id="Koa-jz-hwk"/>
+                <constraint firstAttribute="bottom" secondItem="8ie-xW-0ye" secondAttribute="bottom" constant="20" id="Kzo-t9-V3l"/>
+                <constraint firstItem="8ie-xW-0ye" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="20" symbolic="YES" id="MfP-vx-nX0"/>
+                <constraint firstAttribute="centerX" secondItem="8ie-xW-0ye" secondAttribute="centerX" id="ZEH-qu-HZ9"/>
+                <constraint firstItem="kId-c2-rCX" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="20" symbolic="YES" id="fvb-Df-36g"/>
+            </constraints>
+            <nil key="simulatedStatusBarMetrics"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <point key="canvasLocation" x="548" y="455"/>
+        </view>
+    </objects>
+</document>

--- a/RBQFetchedResultsControllerSwiftExample/RBQFetchedResultsControllerSwiftExample/Base.lproj/Main.storyboard
+++ b/RBQFetchedResultsControllerSwiftExample/RBQFetchedResultsControllerSwiftExample/Base.lproj/Main.storyboard
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6751" systemVersion="14C1514" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="5hs-e9-aiw">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6736"/>
+    </dependencies>
+    <scenes>
+        <!--Root View Controller-->
+        <scene sceneID="GoF-y2-Dpb">
+            <objects>
+                <tableViewController id="IBI-JV-e4G" customClass="ExampleTableViewController" customModule="RBQFetchedResultsControllerSwiftExample" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" id="8cU-O6-qfG">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <prototypes>
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="customCell" id="87F-YV-uVo">
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="87F-YV-uVo" id="EOf-wU-mwc">
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </tableViewCellContentView>
+                            </tableViewCell>
+                        </prototypes>
+                        <connections>
+                            <outlet property="dataSource" destination="IBI-JV-e4G" id="XCm-tO-6Vf"/>
+                            <outlet property="delegate" destination="IBI-JV-e4G" id="B0P-35-1A0"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" title="Root View Controller" id="OsI-f2-sbf"/>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="fOI-oI-u9M" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1568" y="556"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="FLP-vN-Vvk">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="5hs-e9-aiw" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="s0G-JL-Ta0">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="IBI-JV-e4G" kind="relationship" relationship="rootViewController" id="JUN-kP-nlw"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="qCQ-7k-If8" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="756" y="556"/>
+        </scene>
+    </scenes>
+</document>

--- a/RBQFetchedResultsControllerSwiftExample/RBQFetchedResultsControllerSwiftExample/ExampleTableViewController.swift
+++ b/RBQFetchedResultsControllerSwiftExample/RBQFetchedResultsControllerSwiftExample/ExampleTableViewController.swift
@@ -1,0 +1,257 @@
+//
+//  ExampleTableViewController.swift
+//  RBQFetchedResultsControllerSwiftExample
+//
+//  Created by Jeff on 4/2/15.
+//  Copyright (c) 2015 Jeff. All rights reserved.
+//
+
+import UIKit
+import Realm
+import RBQFetchedResultsController
+
+
+class ExampleTableViewController: UITableViewController, UITableViewDataSource, UITableViewDelegate, RBQFetchedResultsControllerDelegate {
+    
+    // MARK: variables
+    let realm = RLMRealm.defaultRealm()
+    var fetchedResultsController = RBQFetchedResultsController()
+    
+    func setUpFRC () {
+        // Select and sort
+        let predicate = NSPredicate(format: "inTable = YES")  // Can also use %i, %@
+        let sortDescriptor = RLMSortDescriptor(property: "sortIndex", ascending: true)
+        let sortDescriptorSection = RLMSortDescriptor(property: "sectionName", ascending: true)
+        
+        // Set up fetch
+        let fetchRequest = RBQFetchRequest(entityName: "TestObject", inRealm: realm, predicate: predicate) // RBQFetchRequest(entityName: "InOut", inRealm: RLMRealm.defaultRealm(), predicate: predicate)
+        fetchRequest.sortDescriptors = [sortDescriptor, sortDescriptorSection]  // can also be [primarySortDescriptor, secondarySortDescriptor]
+        let fetchedResultsController = RBQFetchedResultsController(fetchRequest: fetchRequest, sectionNameKeyPath: "sectionName", cacheName: "testCache")
+        
+        fetchedResultsController.delegate = self
+        let success = fetchedResultsController.performFetch()
+        
+        println("success: \(success), Total fetched: \(fetchedResultsController.fetchedObjects)")  //fetchedResultsController.fetchedObjects!.count
+    }
+    
+    func initializeDB() {
+        
+        println ("realm.path: \(realm.path)")
+    }
+    
+    
+    
+    
+    // MARK: view
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Do any additional setup after loading the view, typically from a nib.
+        
+        println ("realm.path: \(realm.path)")
+        
+        realm.beginWriteTransaction()
+        realm.deleteAllObjects()
+        
+        for i in 0...1000 {
+            let title = String("Cell \(i)")
+//            let object = TestObject(title: title, sortIndex: i, inTable: true)
+            let object = TestObject()
+            object.title = title
+            object.sortIndex = i
+            object.inTable = true
+
+            object.key = String(format: "\(object.title)\(object.sortIndex)")
+            
+            if i < 10 {
+                object.sectionName = "First Section"
+            } else {
+                object.sectionName = "Second Section"
+            }
+            
+            realm.addObject(object)
+        }
+        
+        realm.commitWriteTransaction()
+        
+        // Set up fetch
+        let predicate = NSPredicate(format: "inTable = YES")  // Can also use %i, %@
+        let fetchRequest = RBQFetchRequest(entityName: "TestObject", inRealm: realm, predicate: predicate)
+        
+        let sortDescriptor = RLMSortDescriptor(property: "sortIndex", ascending: true)
+        let sortDescriptorSection = RLMSortDescriptor(property: "sectionName", ascending: true)
+        
+        fetchRequest.sortDescriptors = [sortDescriptor, sortDescriptorSection]
+        
+        
+        let fetchedResultsController = RBQFetchedResultsController(fetchRequest: fetchRequest, sectionNameKeyPath: "sectionName", cacheName: "testCache")
+        
+        fetchedResultsController.delegate = self
+        let success = fetchedResultsController.performFetch()
+
+    }
+    
+    override func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+        // Dispose of any resources that can be recreated.
+    }
+    
+
+    // MARK: Table view data source
+    
+    override func numberOfSectionsInTableView(tableView: UITableView) -> Int {
+        let numberOfSections = fetchedResultsController.numberOfSections()
+        return numberOfSections
+    }
+    
+    override func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        let numberOfRowsForSectionIndex = fetchedResultsController.numberOfRowsForSectionIndex(section)
+        return fetchedResultsController.numberOfRowsForSectionIndex(section)
+    }
+    
+    override func tableView(tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        let title = fetchedResultsController.titleForHeaderInSection(section)
+        return title
+    }
+    
+    
+    override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
+        
+        var cell = tableView.dequeueReusableCellWithIdentifier("customCell", forIndexPath: indexPath) as UITableViewCell
+        
+        let objectForCell = fetchedResultsController.objectInRealm(realm, atIndexPath: indexPath) as TestObject
+        cell.textLabel?.text = objectForCell.title
+        return cell
+    }
+    
+    override func tableView(tableView: UITableView, canEditRowAtIndexPath indexPath: NSIndexPath) -> Bool {
+        return true
+    }
+    
+    override func tableView(tableView: UITableView, commitEditingStyle editingStyle: UITableViewCellEditingStyle, forRowAtIndexPath indexPath: NSIndexPath) {
+        if (editingStyle == UITableViewCellEditingStyle.Delete) {
+            
+            // Delete the row from the data source
+            self.deleteObjectAtIndexPath(indexPath)
+        } else if (editingStyle == UITableViewCellEditingStyle.Insert) {
+            // Create a new instance of the appropriate class, insert it into the array, and add a new row to the table view
+            self.insertObject()
+        }
+    }
+    
+
+    // MARK: Private
+    func deleteObjectAtIndexPath(indexPath : NSIndexPath) {
+        if let object = fetchedResultsController.objectInRealm(realm, atIndexPath: indexPath) as? TestObject {
+            realm.beginWriteTransaction()
+            realm.deleteObjectWithNotification(object)
+            realm.commitWriteTransaction()
+        }
+    }
+    
+    func insertObject() {
+        let indexPathFirstRow =  NSIndexPath(forRow: 0, inSection: 0)
+        
+        let object = fetchedResultsController.objectInRealm(realm, atIndexPath: indexPathFirstRow) as TestObject
+        
+        if object.sortIndex > 0 {
+            realm.beginWriteTransaction()
+            
+            let sortIndex = object.sortIndex - 1;
+            
+            let title = NSString(format: "Cell %lu", CLong(sortIndex))
+            
+            if let newObject = RLMObject(inRealm: realm, forPrimaryKey: NSString(format: "%@%ld", title, CLong(sortIndex))) {
+                newObject.changeWithNotification{ object in
+                    let testObject = object as TestObject
+                    testObject.inTable = true
+                }
+            } else {
+//                let newObject = TestObject(title: title, sortIndex: sortIndex, inTable: true)
+                let newObject = TestObject()
+                newObject.title = title
+                newObject.sortIndex = sortIndex
+                newObject.inTable = true
+                newObject.sectionName = "First Section"
+                newObject.key = NSString(format: "%@%ld", title, CLong(sortIndex))
+                realm.addObjectWithNotification(newObject)
+            }
+            realm.commitWriteTransaction()
+        }
+        
+
+//    // Test Moves
+//    else {
+//    [realm beginWriteTransaction];
+//    
+//    NSIndexPath *indexPathFifthRow = [NSIndexPath indexPathForRow:5 inSection:0];
+//    NSIndexPath *indexPathThirdRow = [NSIndexPath indexPathForRow:3 inSection:0];
+//    NSIndexPath *indexPathSixthRow = [NSIndexPath indexPathForRow:6 inSection:0];
+//    NSIndexPath *indexPathFirstRow = [NSIndexPath indexPathForRow:0 inSection:0];
+//    
+//    TestObject *firstObject = [self.fetchedResultsController objectInRealm:realm
+//    atIndexPath:indexPathFirstRow];
+//    TestObject *thirdObject = [self.fetchedResultsController objectInRealm:realm
+//    atIndexPath:indexPathThirdRow];
+//    TestObject *fifthObject = [self.fetchedResultsController objectInRealm:realm
+//    atIndexPath:indexPathFifthRow];
+//    TestObject *sixthObject = [self.fetchedResultsController objectInRealm:realm
+//    atIndexPath:indexPathSixthRow];
+//    RLMResults *ninthObject = [TestObject objectsInRealm:realm where:@"%K == %@",@"title",@"Cell 9"];
+//    
+//    [fifthObject changeWithNotification:^(RLMObject *object) {
+//    TestObject *testObject = (TestObject *)object;
+//    
+//    testObject.sortIndex += 1;
+//    }];
+//    
+//    [sixthObject changeWithNotification:^(RLMObject *object) {
+//    TestObject *testObject = (TestObject *)object;
+//    
+//    testObject.sortIndex -= 1;
+//    }];
+//    
+//    [firstObject changeWithNotification:^(RLMObject *object) {
+//    TestObject *testObject = (TestObject *)object;
+//    
+//    testObject.inTable = NO;
+//    }];
+//    
+//    [thirdObject changeWithNotification:^(RLMObject *object) {
+//    TestObject *testObject = (TestObject *)object;
+//    
+//    testObject.title = @"Testing Move And Update";
+//    }];
+//    
+//    if (ninthObject.firstObject) {
+//    [ninthObject.firstObject changeWithNotification:^(RLMObject *object) {
+//    TestObject *testObject = (TestObject *)object;
+//    
+//    if ([testObject.sectionName isEqualToString:@"First Section"]) {
+//    testObject.sectionName = @"Second Section";
+//    }
+//    else {
+//    testObject.sectionName = @"First Section";
+//    }
+//    }];
+//    }
+//    
+//    //Test an inserted section that's not first
+//    //        TestObject *extraObjectInSection = [TestObject testObjectWithTitle:@"Test Section" sortIndex:3 inTable:YES];
+//    //        extraObjectInSection.sectionName = @"Middle Section";
+//    //        [realm addObject:extraObjectInSection];
+//    //
+//    //        [[RBQRealmNotificationManager defaultManager] didAddObjects:@[extraObjectInSection]
+//    //                                                  willDeleteObjects:nil
+//    //                                                   didChangeObjects:@[NULL_IF_NIL(fifthObject),
+//    //                                                                      NULL_IF_NIL(sixthObject),
+//    //                                                                      NULL_IF_NIL(firstObject),
+//    //                                                                      NULL_IF_NIL(thirdObject)]];
+//    
+//    [realm commitWriteTransaction];
+//    }
+//    }
+    
+   }
+    
+}

--- a/RBQFetchedResultsControllerSwiftExample/RBQFetchedResultsControllerSwiftExample/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/RBQFetchedResultsControllerSwiftExample/RBQFetchedResultsControllerSwiftExample/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,68 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/RBQFetchedResultsControllerSwiftExample/RBQFetchedResultsControllerSwiftExample/Info.plist
+++ b/RBQFetchedResultsControllerSwiftExample/RBQFetchedResultsControllerSwiftExample/Info.plist
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.brisdo.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/RBQFetchedResultsControllerSwiftExample/RBQFetchedResultsControllerSwiftExample/RLMSupport.swift
+++ b/RBQFetchedResultsControllerSwiftExample/RBQFetchedResultsControllerSwiftExample/RLMSupport.swift
@@ -1,0 +1,78 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2014 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import Realm
+
+extension RLMObject {
+    // Swift query convenience functions
+    public class func objectsWhere(predicateFormat: String, _ args: CVarArgType...) -> RLMResults {
+        return objectsWithPredicate(NSPredicate(format: predicateFormat, arguments: getVaList(args)))
+    }
+
+    public class func objectsInRealm(realm: RLMRealm, _ predicateFormat: String, _ args: CVarArgType...) -> RLMResults {
+        return objectsInRealm(realm, withPredicate:NSPredicate(format: predicateFormat, arguments: getVaList(args)))
+    }
+}
+
+extension RLMArray: SequenceType {
+    // Support Sequence-style enumeration
+    public func generate() -> GeneratorOf<RLMObject> {
+        var i: UInt  = 0
+
+        return GeneratorOf<RLMObject> {
+            if (i >= self.count) {
+                return .None
+            } else {
+                return self[i++] as? RLMObject
+            }
+        }
+    }
+
+    // Swift query convenience functions
+    public func indexOfObjectWhere(predicateFormat: String, _ args: CVarArgType...) -> UInt {
+        return indexOfObjectWithPredicate(NSPredicate(format: predicateFormat, arguments: getVaList(args)))
+    }
+
+    public func objectsWhere(predicateFormat: String, _ args: CVarArgType...) -> RLMResults {
+        return objectsWithPredicate(NSPredicate(format: predicateFormat, arguments: getVaList(args)))
+    }
+}
+
+extension RLMResults: SequenceType {
+    // Support Sequence-style enumeration
+    public func generate() -> GeneratorOf<RLMObject> {
+        var i: UInt  = 0
+
+        return GeneratorOf<RLMObject> {
+            if (i >= self.count) {
+                return .None
+            } else {
+                return self[i++] as? RLMObject
+            }
+        }
+    }
+
+    // Swift query convenience functions
+    public func indexOfObjectWhere(predicateFormat: String, _ args: CVarArgType...) -> UInt {
+        return indexOfObjectWithPredicate(NSPredicate(format: predicateFormat, arguments: getVaList(args)))
+    }
+
+    public func objectsWhere(predicateFormat: String, _ args: CVarArgType...) -> RLMResults {
+        return objectsWithPredicate(NSPredicate(format: predicateFormat, arguments: getVaList(args)))
+    }
+}

--- a/RBQFetchedResultsControllerSwiftExample/RBQFetchedResultsControllerSwiftExample/TestObject.swift
+++ b/RBQFetchedResultsControllerSwiftExample/RBQFetchedResultsControllerSwiftExample/TestObject.swift
@@ -1,0 +1,30 @@
+//
+//  TestObject.swift
+//  TimeHenPersonal
+//
+//  Created by Jeff on 4/1/15.
+//  Copyright (c) 2015 Jeff. All rights reserved.
+//
+
+
+import Realm
+
+class TestObject: RLMObject {
+    dynamic var title : NSString = "Default Title"
+    dynamic var sortIndex : NSInteger = 0
+    dynamic var sectionName : NSString = "Section 1"
+    dynamic var key : NSString = "Section 1"
+    dynamic var inTable : Bool = true
+    
+    override class func primaryKey() -> String {
+        return "key"
+    }
+    
+//    init(title: NSString, sortIndex: NSInteger, inTable: Bool) {
+//        super.init()
+//        self.sortIndex = sortIndex
+//        self.title = title
+//        self.key = NSString(format: "%@%ld", title, CLong(sortIndex))
+//        self.inTable = inTable
+//    }
+}

--- a/RBQFetchedResultsControllerSwiftExample/RBQFetchedResultsControllerSwiftExample/ViewController.swift
+++ b/RBQFetchedResultsControllerSwiftExample/RBQFetchedResultsControllerSwiftExample/ViewController.swift
@@ -1,0 +1,25 @@
+//
+//  ViewController.swift
+//  RBQFetchedResultsControllerSwiftExample
+//
+//  Created by Jeff on 4/2/15.
+//  Copyright (c) 2015 Jeff. All rights reserved.
+//
+
+import UIKit
+
+class ViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Do any additional setup after loading the view, typically from a nib.
+    }
+
+    override func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+        // Dispose of any resources that can be recreated.
+    }
+
+
+}
+

--- a/RBQFetchedResultsControllerSwiftExample/RBQFetchedResultsControllerSwiftExampleTests/Info.plist
+++ b/RBQFetchedResultsControllerSwiftExample/RBQFetchedResultsControllerSwiftExampleTests/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.brisdo.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/RBQFetchedResultsControllerSwiftExample/RBQFetchedResultsControllerSwiftExampleTests/RBQFetchedResultsControllerSwiftExampleTests.swift
+++ b/RBQFetchedResultsControllerSwiftExample/RBQFetchedResultsControllerSwiftExampleTests/RBQFetchedResultsControllerSwiftExampleTests.swift
@@ -1,0 +1,36 @@
+//
+//  RBQFetchedResultsControllerSwiftExampleTests.swift
+//  RBQFetchedResultsControllerSwiftExampleTests
+//
+//  Created by Jeff on 4/2/15.
+//  Copyright (c) 2015 Jeff. All rights reserved.
+//
+
+import UIKit
+import XCTest
+
+class RBQFetchedResultsControllerSwiftExampleTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+    func testExample() {
+        // This is an example of a functional test case.
+        XCTAssert(true, "Pass")
+    }
+    
+    func testPerformanceExample() {
+        // This is an example of a performance test case.
+        self.measureBlock() {
+            // Put the code you want to measure the time of here.
+        }
+    }
+    
+}


### PR DESCRIPTION
Hi Adam,

Sorry i mis-read your post today.   This pull request adds a 2nd example, which might serve 2 purposes:

1) Eventually act as a example of how to use RBQFetchedResultsController with Swift (though not yet because it doesn't work :)
2) As I mentioned, it appears that RBQFetchedResultsController isn't returning any records.  If you have any interest/time in debugging, this might act as a starting point.  

If you'd prefer to that I debug, that's fine as well - any suggestions on where to look/get started would be appreciated.

Note that, In addition, I needed to make the following modifications to the #imports
in the following files in the RBQFetchedResultsControllerSwiftExample
pod:

FILE                                 OLD Value
NEW value
RBQSafeRealmObject.h  #import "RLMProperty.h"   #import
<Realm/RLMProperty.h>
RLMObject+Notifications.h #import "RLMObject.h"  #import
<Realm/RLMObject.h>
RLMRealm+Notifications.h  #import "RLMRealm.h"  #import
<Realm/RLMRealm.h>
RLMObject+SafeObject.h  #import "RLMObject.h"   #import
<Realm/RLMObject.h>
RLMObject+Utilities.h        #import "RLMObject.h"   #import
<Realm/RLMObject.h>