### PR TITLE
Add specific version for Realm in Podfile

### DIFF
--- a/RBQFetchedResultsControllerExample/Podfile
+++ b/RBQFetchedResultsControllerExample/Podfile
@@ -2,7 +2,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '8.0'
 
 target 'RBQFetchedResultsControllerExample' do
-    pod 'Realm'
+    pod 'Realm', '~> 0.92.4'
     pod 'RBQFetchedResultsController'
 end
 


### PR DESCRIPTION
I think for now `Podfile` is not specified Realm version, so when run `pod install` it will be installed `Realm 0.93.0` and actually I've been occurred build error below.(Because Migration API was changed in 0.93.0)

![2015-05-28 13 31 03](https://cloud.githubusercontent.com/assets/1756640/7870623/6ade027a-053f-11e5-829f-21056a915b72.png)

So it needs to support for Realm 0.93.0 or describe version in `Podfile` or share `Podfile.lock`, I think.