### PR TITLE
Change to - objectAtIndexPath: in example

### DIFF
--- a/RBQFetchedResultsControllerExample/RBQFetchedResultsControllerExample/ExampleTableViewController.m
+++ b/RBQFetchedResultsControllerExample/RBQFetchedResultsControllerExample/ExampleTableViewController.m
@@ -104,11 +104,8 @@ id NULL_IF_NIL(id x) {return x ? x : NSNull.null;}
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"customCell" forIndexPath:indexPath];
     
     // Configure the cell...
-    TestObject *objectForCell = [self.fetchedResultsController objectInRealm:[RLMRealm defaultRealm]
-                                                                 atIndexPath:indexPath];
-    
+    TestObject *objectForCell = [self.fetchedResultsController objectAtIndexPath:indexPath];
     cell.textLabel.text = objectForCell.title;
-    
     
     return cell;
 }
@@ -258,17 +255,14 @@ forRowAtIndexPath:(NSIndexPath *)indexPath
 - (void)deleteObjectAtIndexPath:(NSIndexPath *)indexPath
 {
     RLMRealm *realm = [RLMRealm defaultRealm];
+    TestObject *object = [self.fetchedResultsController objectAtIndexPath:indexPath];
     
-    TestObject *object = [self.fetchedResultsController objectInRealm:realm
-                                                          atIndexPath:indexPath];
     if (!object) {
         return;
     }
     
     [realm beginWriteTransaction];
-    
     [realm deleteObjectWithNotification:object];
-    
     [realm commitWriteTransaction];
 }
 
@@ -277,9 +271,7 @@ forRowAtIndexPath:(NSIndexPath *)indexPath
     RLMRealm *realm = [RLMRealm defaultRealm];
     
     NSIndexPath *indexPathFirstRow = [NSIndexPath indexPathForRow:0 inSection:0];
-    
-    TestObject *object = [self.fetchedResultsController objectInRealm:realm
-                                                          atIndexPath:indexPathFirstRow];
+    TestObject *object = [self.fetchedResultsController objectAtIndexPath:indexPathFirstRow];
     
     if (object.sortIndex > 0) {
         [realm beginWriteTransaction];
@@ -319,33 +311,25 @@ forRowAtIndexPath:(NSIndexPath *)indexPath
         NSIndexPath *indexPathSixthRow = [NSIndexPath indexPathForRow:6 inSection:0];
         NSIndexPath *indexPathFirstRow = [NSIndexPath indexPathForRow:0 inSection:0];
         
-        TestObject *firstObject = [self.fetchedResultsController objectInRealm:realm
-                                                                   atIndexPath:indexPathFirstRow];
-        TestObject *thirdObject = [self.fetchedResultsController objectInRealm:realm
-                                                                   atIndexPath:indexPathThirdRow];
-        TestObject *fifthObject = [self.fetchedResultsController objectInRealm:realm
-                                                                   atIndexPath:indexPathFifthRow];
-        TestObject *sixthObject = [self.fetchedResultsController objectInRealm:realm
-                                                                   atIndexPath:indexPathSixthRow];
+        TestObject *firstObject = [self.fetchedResultsController objectAtIndexPath:indexPathFirstRow];
+        TestObject *thirdObject = [self.fetchedResultsController objectAtIndexPath:indexPathThirdRow];
+        TestObject *fifthObject = [self.fetchedResultsController objectAtIndexPath:indexPathFifthRow];
+        TestObject *sixthObject = [self.fetchedResultsController objectAtIndexPath:indexPathSixthRow];
         RLMResults *ninthObject = [TestObject objectsInRealm:realm where:@"%K == %@",@"title",@"Cell 9"];
         
         [fifthObject changeWithNotification:^(TestObject *testObject) {
-            
             testObject.sortIndex += 1;
         }];
         
         [sixthObject changeWithNotification:^(TestObject *testObject) {
-            
             testObject.sortIndex -= 1;
         }];
         
         [firstObject changeWithNotification:^(TestObject *testObject) {
-            
             testObject.inTable = NO;
         }];
         
         [thirdObject changeWithNotification:^(TestObject *testObject) {
-            
             testObject.title = @"Testing Move And Update";
         }];
         


### PR DESCRIPTION
I think it should be used `- objectAtIndexPath:` instead of `- objectInRealm:atIndexPath:`. Because example will be more simple. What do you think? @bigfish24 