### PR TITLE
Fix bug

### DIFF
--- a/RBQFetchedResultsController/RBQFetchedResultsController.m
+++ b/RBQFetchedResultsController/RBQFetchedResultsController.m
@@ -12,6 +12,7 @@
 #import "RBQRealmNotificationManager.h"
 #import "RBQControllerCacheObject.h"
 #import "RBQSectionCacheObject.h"
+#import "RLMArray+Utilities.h"
 
 #import <objc/runtime.h>
 
@@ -1037,7 +1038,9 @@ static char kRBQRefreshTriggeredKey;
                         [cacheRealm addOrUpdateObject:section];
                         
                         // Add the section to the controller cache
-                        [controllerCache.sections addObject:section];
+                        if (![controllerCache.sections containsObject:section]) {
+                            [controllerCache.sections addObject:section];
+                        }
                     }
                     
                     // Keep track of the section title so we create one section cache per value
@@ -1054,7 +1057,9 @@ static char kRBQRefreshTriggeredKey;
                 // Add the section to Realm
                 [cacheRealm addOrUpdateObject:section];
                 
-                [controllerCache.sections addObject:section];
+                if (![controllerCache.sections containsObject:section]) {
+                    [controllerCache.sections addObject:section];
+                }
             }
             
             // Create the cache object


### PR DESCRIPTION
I've found the bug when I write test of `RBQFetchedResultsController` class.

When I stored date like below:

![2015-05-29 15 21 57](https://cloud.githubusercontent.com/assets/1756640/7894642/5f9455c0-0622-11e5-9562-a9bda839c0ad.png)

Even though section type is 2 types(`section 1` and `section 2`), but `self.fetchedResultsController numberOfSections` will return 10 because `[controllerCache.sections addObject:section];` will be called 10 times in `- createCacheWithRealm:cacheName:forFetchRequest:sectionNameKeyPath:` method.