### PR TITLE
Improved concurrency and deprecated tracking cache state

### DIFF
--- a/RBQFetchedResultsController/CacheObjects/RBQControllerCacheObject.h
+++ b/RBQFetchedResultsController/CacheObjects/RBQControllerCacheObject.h
@@ -47,7 +47,7 @@ RLM_ARRAY_TYPE(RBQSectionCacheObject)
  *
  *  @warning If cache is not ready, when requested, it will be rebuilt (this can occur if the app is forced closed while the cache is processing.
  */
-@property NSInteger state;
+@property NSInteger state DEPRECATED_MSG_ATTRIBUTE("Do not use.");
 
 /**
  *  Used to track the current section name key path if any for the cache

--- a/RBQFetchedResultsController/CacheObjects/RBQControllerCacheObject.m
+++ b/RBQFetchedResultsController/CacheObjects/RBQControllerCacheObject.m
@@ -16,7 +16,6 @@
     RBQControllerCacheObject *cache = [[RBQControllerCacheObject alloc] init];
     cache.name = name;
     cache.fetchRequestHash = hash;
-    cache.state = RBQControllerCacheStateReady;
     
     return cache;
 }

--- a/RBQFetchedResultsController/RBQFetchedResultsController.m
+++ b/RBQFetchedResultsController/RBQFetchedResultsController.m
@@ -616,7 +616,10 @@ static char kRBQRefreshTriggeredKey;
     _fetchRequest = fetchRequest;
     
     if (performFetch) {
-        [self performFetch];
+        // Only performFetch if the change processing is finished
+        @synchronized(self) {
+            [self performFetch];
+        }
     }
 }
 

--- a/RBQFetchedResultsController/RBQFetchedResultsController.m
+++ b/RBQFetchedResultsController/RBQFetchedResultsController.m
@@ -607,17 +607,17 @@ static char kRBQRefreshTriggeredKey;
         sectionNameKeyPath:(NSString *)sectionNameKeyPath
             andPeformFetch:(BOOL)performFetch
 {
-    // Turn off change notifications since we are replacing fetch request
-    // Change notifications will be re-registered if performFetch is called
-    [self unregisterChangeNotifications];
-    
-    // Updating the fetch request will force rebuild of cache automatically
-    _sectionNameKeyPath = sectionNameKeyPath;
-    _fetchRequest = fetchRequest;
-    
-    if (performFetch) {
-        // Only performFetch if the change processing is finished
-        @synchronized(self) {
+    @synchronized(self) {
+        // Turn off change notifications since we are replacing fetch request
+        // Change notifications will be re-registered if performFetch is called
+        [self unregisterChangeNotifications];
+        
+        // Updating the fetch request will force rebuild of cache automatically
+        _sectionNameKeyPath = sectionNameKeyPath;
+        _fetchRequest = fetchRequest;
+        
+        if (performFetch) {
+            // Only performFetch if the change processing is finished
             [self performFetch];
         }
     }

--- a/RBQFetchedResultsController/RBQFetchedResultsController.m
+++ b/RBQFetchedResultsController/RBQFetchedResultsController.m
@@ -607,6 +607,10 @@ static char kRBQRefreshTriggeredKey;
         sectionNameKeyPath:(NSString *)sectionNameKeyPath
             andPeformFetch:(BOOL)performFetch
 {
+    // Turn off change notifications since we are replacing fetch request
+    // Change notifications will be re-registered if performFetch is called
+    [self unregisterChangeNotifications];
+    
     // Updating the fetch request will force rebuild of cache automatically
     _sectionNameKeyPath = sectionNameKeyPath;
     _fetchRequest = fetchRequest;


### PR DESCRIPTION
Improved the safety of calling `updateFetchRequest:` so that it runs serially in relation to the change processing. Also, got rid of any use of the state property on the controller cache object. Did not remove the property as this would require users to migrate the Realm, but instead just marked the property as deprecated (internal use anyway).