### PR TITLE
Deprecated a few method related to in-memory Realms

### DIFF
--- a/RBQFetchedResultsController/RBQFetchRequest.h
+++ b/RBQFetchedResultsController/RBQFetchRequest.h
@@ -32,6 +32,13 @@
 @property (nonatomic, readonly) NSString *realmPath;
 
 /**
+ *  The identifier of the in-memory Realm.
+ *
+ *  @warning return nil if fetch request initialized without in-memory Realm
+ */
+@property (nonatomic, readonly) NSString *inMemoryRealmId;
+
+/**
  *  Predicate supported by Realm
  *
  *  http://realm.io/docs/cocoa/0.89.2/#querying-with-predicates
@@ -50,7 +57,7 @@
  *  Constructor method to create a fetch request for a given entity name in a specific Realm.
  *
  *  @param entityName Class name for the RLMObject
- *  @param realm      RLMRealm in which the RLMObject is persisted
+ *  @param realm      RLMRealm in which the RLMObject is persisted (if passing in-memory Realm, make sure to keep a strong reference elsewhere since fetch request only stores the path)
  *  @param predicate  NSPredicate that represents the search query
  *
  *  @return A new instance of RBQFetchRequest
@@ -63,7 +70,7 @@
  *  Constructor method to create a fetch request for a given entity name in an in-memory Realm.
  *
  *  @param entityName Class name for the RLMObject
- *  @param inMemoryRealm In-memory RLMRealm in which the RLMObject is persisted
+ *  @param inMemoryRealm In-memory RLMRealm in which the RLMObject is persisted (caller must retain strong reference as fetch request does not)
  *  @param predicate  NSPredicate that represents the search query
  *
  *  @return A new instance of RBQFetchRequest

--- a/RBQFetchedResultsController/RBQFetchRequest.m
+++ b/RBQFetchedResultsController/RBQFetchRequest.m
@@ -11,14 +11,14 @@
 
 @interface RBQFetchRequest ()
 
-@property (weak, nonatomic) RLMRealm *inMemoryRealm;
 @property (strong, nonatomic) RLMRealm *realmForMainThread; // Improves scroll performance
 
 @end
 
 @implementation RBQFetchRequest
 @synthesize entityName = _entityName,
-realmPath = _realmPath;
+realmPath = _realmPath,
+inMemoryRealmId = _inMemoryRealmId;
 
 #pragma mark - Private Class
 
@@ -72,7 +72,7 @@ realmPath = _realmPath;
     if (self) {
         // Returns the appropriate class name for Obj-C or Swift
         _entityName = [RBQFetchRequest verifyEntityName:entityName];
-        _inMemoryRealm = inMemoryRealm;
+        _inMemoryRealmId = inMemoryRealm.path.lastPathComponent;
         _realmPath = inMemoryRealm.path;
     }
     
@@ -133,8 +133,8 @@ realmPath = _realmPath;
 
 - (RLMRealm *)realm
 {
-    if (self.inMemoryRealm) {
-        return self.inMemoryRealm;
+    if (self.inMemoryRealmId) {
+        return [RLMRealm inMemoryRealmWithIdentifier:self.inMemoryRealmId];
     }
     
     if ([NSThread isMainThread] &&

--- a/RBQFetchedResultsController/RBQFetchedResultsController.h
+++ b/RBQFetchedResultsController/RBQFetchedResultsController.h
@@ -182,7 +182,7 @@
  */
 - (id)initWithFetchRequest:(RBQFetchRequest *)fetchRequest
         sectionNameKeyPath:(NSString *)sectionNameKeyPath
-        inMemoryRealmCache:(RLMRealm *)inMemoryRealm;
+        inMemoryRealmCache:(RLMRealm *)inMemoryRealm DEPRECATED_MSG_ATTRIBUTE("Please use initWithFetchRequest:sectionNameKeyPath:cacheName passing nil as the cacheName to use an in-memory Realm cache");
 
 /**
  *  Method to tell the controller to perform the fetch
@@ -263,7 +263,7 @@
  *  @return RLMObject
  */
 - (id)objectInRealm:(RLMRealm *)realm
-        atIndexPath:(NSIndexPath *)indexPath;
+        atIndexPath:(NSIndexPath *)indexPath DEPRECATED_MSG_ATTRIBUTE("Use objectAtIndexPath:");
 
 /**
  *  Retrieve the index path for a safe object in the fetch request

--- a/RBQFetchedResultsController/RBQFetchedResultsController.h
+++ b/RBQFetchedResultsController/RBQFetchedResultsController.h
@@ -160,7 +160,7 @@
  *  @warning Specify a cache name if deletion of the cache later on is necessary
  *
  *  @param fetchRequest       the RBQFetchRequest for the controller
- *  @param sectionNameKeyPath the section name key path used to create sections (can be nil)
+ *  @param sectionNameKeyPath A key path on result objects that returns the section name. Pass nil to indicate that the controller should generate a single section. If this key path is not the same as that specified by the first sort descriptor in fetchRequest, they must generate the same relative orderings.
  *  @param name               the cache name (if nil, cache will not be persisted and built using an in-memory Realm)
  *
  *  @return A new instance of RBQFetchedResultsController

--- a/RBQFetchedResultsController/RBQFetchedResultsController.m
+++ b/RBQFetchedResultsController/RBQFetchedResultsController.m
@@ -25,7 +25,7 @@ static char kRBQRefreshTriggeredKey;
 @interface RBQFetchedResultsController ()
 
 @property (strong, nonatomic) RBQNotificationToken *notificationToken;
-@property (weak, nonatomic) RLMRealm *inMemoryRealmCache;
+@property (strong, nonatomic) RLMRealm *inMemoryRealmCache;
 @property (strong, nonatomic) RLMRealm *realmForMainThread; // Improves scroll performance
 
 @end
@@ -1897,17 +1897,12 @@ static char kRBQRefreshTriggeredKey;
     }
     else {
         
-        if ([NSThread isMainThread] &&
-            self.realmForMainThread) {
-            
-            return self.realmForMainThread;
-        }
-        
         RLMRealm *realm = [RLMRealm inMemoryRealmWithIdentifier:[self nameForFetchRequest:self.fetchRequest]];
         
-        if ([NSThread isMainThread]) {
+        // Hold onto a strong reference so inMemory realm cache doesn't get deallocated
+        if (!self.inMemoryRealmCache) {
             
-            self.realmForMainThread = realm;
+            self.inMemoryRealmCache = realm;
         }
         
         return realm;

--- a/RBQFetchedResultsControllerExample/Podfile
+++ b/RBQFetchedResultsControllerExample/Podfile
@@ -3,7 +3,7 @@ platform :ios, '8.0'
 
 target 'RBQFetchedResultsControllerExample' do
     pod 'Realm', '~> 0.93.1'
-#    pod 'RBQFetchedResultsController'
+    pod 'RBQFetchedResultsController'
 end
 
 target 'RBQFetchedResultsControllerExampleTests' do

--- a/RBQFetchedResultsControllerExample/Podfile
+++ b/RBQFetchedResultsControllerExample/Podfile
@@ -2,8 +2,8 @@ source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '8.0'
 
 target 'RBQFetchedResultsControllerExample' do
-    pod 'Realm', '~> 0.93.0'
-    pod 'RBQFetchedResultsController'
+    pod 'Realm', '~> 0.93.1'
+#    pod 'RBQFetchedResultsController'
 end
 
 target 'RBQFetchedResultsControllerExampleTests' do

--- a/RBQFetchedResultsControllerExample/RBQFetchedResultsControllerExample.xcodeproj/project.pbxproj
+++ b/RBQFetchedResultsControllerExample/RBQFetchedResultsControllerExample.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		49527C091B17F47500C115A3 /* RBQSafeRealmObjectTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 49527C081B17F47500C115A3 /* RBQSafeRealmObjectTests.m */; };
 		49DF57321B17B09900BA8DDC /* RBQFetchRequestTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 49DF57301B17B09900BA8DDC /* RBQFetchRequestTests.m */; };
 		49DF57331B17B09900BA8DDC /* RBQRealmChangeLoggerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 49DF57311B17B09900BA8DDC /* RBQRealmChangeLoggerTests.m */; };
+		660F4C0A1B19413B00492DAE /* RBQFetchRequestInMemoryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 660F4C091B19413B00492DAE /* RBQFetchRequestInMemoryTests.m */; };
 		662C46951A623B6200A8D145 /* RBQFetchedResultsControllerDelegateTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 662C46941A623B6200A8D145 /* RBQFetchedResultsControllerDelegateTests.m */; };
 		662C46971A6243A900A8D145 /* TestObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 667F383E1A5B26C5008E3052 /* TestObject.m */; };
 		667F380B1A5B2682008E3052 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 667F380A1A5B2682008E3052 /* main.m */; };
@@ -41,6 +42,7 @@
 		49DF57301B17B09900BA8DDC /* RBQFetchRequestTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RBQFetchRequestTests.m; sourceTree = "<group>"; };
 		49DF57311B17B09900BA8DDC /* RBQRealmChangeLoggerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RBQRealmChangeLoggerTests.m; sourceTree = "<group>"; };
 		55AAFFD7A898D4859B81F711 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
+		660F4C091B19413B00492DAE /* RBQFetchRequestInMemoryTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RBQFetchRequestInMemoryTests.m; sourceTree = "<group>"; };
 		662C46941A623B6200A8D145 /* RBQFetchedResultsControllerDelegateTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RBQFetchedResultsControllerDelegateTests.m; sourceTree = "<group>"; };
 		667F38051A5B2682008E3052 /* RBQFetchedResultsControllerExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RBQFetchedResultsControllerExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		667F38091A5B2682008E3052 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -144,6 +146,7 @@
 			children = (
 				662C46941A623B6200A8D145 /* RBQFetchedResultsControllerDelegateTests.m */,
 				49DF57301B17B09900BA8DDC /* RBQFetchRequestTests.m */,
+				660F4C091B19413B00492DAE /* RBQFetchRequestInMemoryTests.m */,
 				49DF57311B17B09900BA8DDC /* RBQRealmChangeLoggerTests.m */,
 				49527C081B17F47500C115A3 /* RBQSafeRealmObjectTests.m */,
 				667F38221A5B2682008E3052 /* Supporting Files */,
@@ -350,6 +353,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				660F4C0A1B19413B00492DAE /* RBQFetchRequestInMemoryTests.m in Sources */,
 				49DF57321B17B09900BA8DDC /* RBQFetchRequestTests.m in Sources */,
 				49DF57331B17B09900BA8DDC /* RBQRealmChangeLoggerTests.m in Sources */,
 				662C46971A6243A900A8D145 /* TestObject.m in Sources */,

--- a/RBQFetchedResultsControllerExample/RBQFetchedResultsControllerExample/ExampleTableViewController.m
+++ b/RBQFetchedResultsControllerExample/RBQFetchedResultsControllerExample/ExampleTableViewController.m
@@ -104,8 +104,7 @@ id NULL_IF_NIL(id x) {return x ? x : NSNull.null;}
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"customCell" forIndexPath:indexPath];
     
     // Configure the cell...
-    TestObject *objectForCell = [self.fetchedResultsController objectInRealm:[RLMRealm defaultRealm]
-                                                                 atIndexPath:indexPath];
+    TestObject *objectForCell = [self.fetchedResultsController objectAtIndexPath:indexPath];
     
     cell.textLabel.text = objectForCell.title;
     
@@ -257,13 +256,12 @@ forRowAtIndexPath:(NSIndexPath *)indexPath
 
 - (void)deleteObjectAtIndexPath:(NSIndexPath *)indexPath
 {
-    RLMRealm *realm = [RLMRealm defaultRealm];
-    
-    TestObject *object = [self.fetchedResultsController objectInRealm:realm
-                                                          atIndexPath:indexPath];
+    TestObject *object = [self.fetchedResultsController objectAtIndexPath:indexPath];
     if (!object) {
         return;
     }
+    
+    RLMRealm *realm = [RLMRealm defaultRealm];
     
     [realm beginWriteTransaction];
     
@@ -278,8 +276,7 @@ forRowAtIndexPath:(NSIndexPath *)indexPath
     
     NSIndexPath *indexPathFirstRow = [NSIndexPath indexPathForRow:0 inSection:0];
     
-    TestObject *object = [self.fetchedResultsController objectInRealm:realm
-                                                          atIndexPath:indexPathFirstRow];
+    TestObject *object = [self.fetchedResultsController objectAtIndexPath:indexPathFirstRow];
     
     if (object.sortIndex > 0) {
         [realm beginWriteTransaction];
@@ -319,14 +316,10 @@ forRowAtIndexPath:(NSIndexPath *)indexPath
         NSIndexPath *indexPathSixthRow = [NSIndexPath indexPathForRow:6 inSection:0];
         NSIndexPath *indexPathFirstRow = [NSIndexPath indexPathForRow:0 inSection:0];
         
-        TestObject *firstObject = [self.fetchedResultsController objectInRealm:realm
-                                                                   atIndexPath:indexPathFirstRow];
-        TestObject *thirdObject = [self.fetchedResultsController objectInRealm:realm
-                                                                   atIndexPath:indexPathThirdRow];
-        TestObject *fifthObject = [self.fetchedResultsController objectInRealm:realm
-                                                                   atIndexPath:indexPathFifthRow];
-        TestObject *sixthObject = [self.fetchedResultsController objectInRealm:realm
-                                                                   atIndexPath:indexPathSixthRow];
+        TestObject *firstObject = [self.fetchedResultsController objectAtIndexPath:indexPathFirstRow];
+        TestObject *thirdObject = [self.fetchedResultsController objectAtIndexPath:indexPathThirdRow];
+        TestObject *fifthObject = [self.fetchedResultsController objectAtIndexPath:indexPathFifthRow];
+        TestObject *sixthObject = [self.fetchedResultsController objectAtIndexPath:indexPathSixthRow];
         RLMResults *ninthObject = [TestObject objectsInRealm:realm where:@"%K == %@",@"title",@"Cell 9"];
         
         [fifthObject changeWithNotification:^(TestObject *testObject) {

--- a/RBQFetchedResultsControllerExample/RBQFetchedResultsControllerExampleTests/RBQFetchRequestInMemoryTests.m
+++ b/RBQFetchedResultsControllerExample/RBQFetchedResultsControllerExampleTests/RBQFetchRequestInMemoryTests.m
@@ -1,39 +1,39 @@
 //
-//  RBQFetchRequestTests.m
+//  RBQFetchRequestInMemoryTests.m
 //  RBQFetchedResultsControllerExample
 //
-//  Created by AsanoYuki on 2015/05/27.
-//  Copyright (c) 2015年 Roobiq. All rights reserved.
+//  Created by Adam Fish on 5/29/15.
+//  Copyright (c) 2015 Roobiq. All rights reserved.
 //
 
+#import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
+
 #import "RBQFetchRequest.h"
 #import "RLMRealm.h"
 #import "TestObject.h"
 
-@interface RBQFetchRequestTests : XCTestCase
+@interface RBQFetchRequestInMemoryTests : XCTestCase
+
+@property (strong, nonatomic) RLMRealm *inMemoryRealm;
 
 @end
 
-@implementation RBQFetchRequestTests
+@implementation RBQFetchRequestInMemoryTests
 
 - (void)setUp
 {
     [super setUp];
     // Put setup code here. This method is called before the invocation of each test method in the class.
-    NSArray *writablePaths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
     
-    NSString *documentsPath = [writablePaths lastObject];
+    // Setup the DB (use random strings to create new versions each time)
+    NSString *identifier = [[NSProcessInfo processInfo] globallyUniqueString];
     
-    NSString *testRealmFile = [documentsPath stringByAppendingPathComponent:@"test.realm"];
+    self.inMemoryRealm = [RLMRealm inMemoryRealmWithIdentifier:identifier];
     
-    [RLMRealm setDefaultRealmPath:testRealmFile];
-    
-    RLMRealm *realm = [RLMRealm defaultRealm];
-    
-    [realm transactionWithBlock:^{
+    [self.inMemoryRealm transactionWithBlock:^{
         
-        [realm deleteAllObjects];
+        [self.inMemoryRealm deleteAllObjects];
         
         for (int i=0; i < 10; i++) {
             
@@ -53,7 +53,7 @@
                 testObject.inTable = NO;
             }
             
-            [realm addObject:testObject];
+            [self.inMemoryRealm addObject:testObject];
         }
     }];
 }
@@ -63,7 +63,7 @@
     // Put teardown code here. This method is called after the invocation of each test method in the class.
     [super tearDown];
     
-    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealm *realm = self.inMemoryRealm;
     
     [realm transactionWithBlock:^{
         
@@ -76,7 +76,7 @@
     NSPredicate *predicate = [NSPredicate predicateWithFormat:@"inTable = YES"];
     
     RBQFetchRequest *fetchRequest = [RBQFetchRequest fetchRequestWithEntityName:@"TestObject"
-                                                                        inRealm:[RLMRealm defaultRealm]
+                                                                  inMemoryRealm:self.inMemoryRealm
                                                                       predicate:predicate];
     
     XCTAssert([fetchRequest.entityName isEqualToString:@"TestObject"]);
@@ -89,11 +89,12 @@
     NSPredicate *predicate = [NSPredicate predicateWithFormat:@"inTable = YES"];
     
     RBQFetchRequest *fetchRequest = [RBQFetchRequest fetchRequestWithEntityName:@"TestObject"
-                                                                        inRealm:[RLMRealm defaultRealm]
+                                                                  inMemoryRealm:self.inMemoryRealm
                                                                       predicate:predicate];
     
     RLMSortDescriptor *sortDescriptor = [RLMSortDescriptor sortDescriptorWithProperty:@"sortIndex"
                                                                             ascending:YES];
+    
     fetchRequest.sortDescriptors = @[sortDescriptor];
     
     RLMResults *results = [fetchRequest fetchObjects];
@@ -109,7 +110,7 @@
     NSPredicate *predicate = [NSPredicate predicateWithFormat:@"inTable = YES"];
     
     RBQFetchRequest *fetchRequest = [RBQFetchRequest fetchRequestWithEntityName:@"TestObject"
-                                                                        inRealm:[RLMRealm defaultRealm]
+                                                                  inMemoryRealm:self.inMemoryRealm
                                                                       predicate:predicate];
     
     TestObject *testObject = [[TestObject alloc] init];
@@ -125,7 +126,7 @@
     NSPredicate *predicate = [NSPredicate predicateWithFormat:@"inTable = YES"];
     
     RBQFetchRequest *fetchRequest = [RBQFetchRequest fetchRequestWithEntityName:@"TestObject"
-                                                                        inRealm:[RLMRealm defaultRealm]
+                                                                  inMemoryRealm:self.inMemoryRealm
                                                                       predicate:predicate];
     
     TestObject *testObject = [[TestObject alloc] init];

--- a/RBQFetchedResultsControllerExample/RBQFetchedResultsControllerExampleTests/RBQFetchedResultsControllerDelegateTests.m
+++ b/RBQFetchedResultsControllerExample/RBQFetchedResultsControllerExampleTests/RBQFetchedResultsControllerDelegateTests.m
@@ -22,7 +22,6 @@
 @property (strong, nonatomic) XCTestExpectation *controllerDidChangeContentExpectation;
 
 @property (strong, nonatomic) RLMRealm *inMemoryRealm;
-@property (strong, nonatomic) RLMRealm *inMemoryRealmCache;
 @property (strong, nonatomic) RBQFetchedResultsController *fetchedResultsController;
 @property (assign, nonatomic) NSUInteger count;
 
@@ -37,9 +36,6 @@
     // Setup the DB (use random strings to create new versions each time)
     NSString *identifier = [[NSProcessInfo processInfo] globallyUniqueString];
     self.inMemoryRealm = [RLMRealm inMemoryRealmWithIdentifier:identifier];
-    
-    identifier = [[NSProcessInfo processInfo] globallyUniqueString];
-    self.inMemoryRealmCache = [RLMRealm inMemoryRealmWithIdentifier:identifier];
     
     // Load the DB with data
     [self.inMemoryRealm beginWriteTransaction];
@@ -82,7 +78,7 @@
     self.fetchedResultsController =
     [[RBQFetchedResultsController alloc] initWithFetchRequest:fetchRequest
                                            sectionNameKeyPath:@"sectionName"
-                                           inMemoryRealmCache:self.inMemoryRealmCache];
+                                                    cacheName:nil];
     
     self.fetchedResultsController.delegate = self;
     
@@ -112,6 +108,7 @@
     [self deleteObjectAtIndexPath:indexPath];
     
     [self waitForExpectationsWithTimeout:5 handler:^(NSError *error) {
+        
         XCTAssertNil(error, @"%@", error.localizedDescription);
     }];
 }
@@ -125,6 +122,7 @@
     [self deleteObjectAtIndexPath:indexPath];
     
     [self waitForExpectationsWithTimeout:5 handler:^(NSError *error) {
+        
         XCTAssertNil(error, @"%@", error.localizedDescription);
     }];
 }
@@ -166,8 +164,8 @@
 
 - (void)deleteObjectAtIndexPath:(NSIndexPath *)indexPath
 {
-    TestObject *object = [self.fetchedResultsController objectInRealm:self.inMemoryRealm
-                                                          atIndexPath:indexPath];
+    TestObject *object = [self.fetchedResultsController objectAtIndexPath:indexPath];
+    
     [self.inMemoryRealm beginWriteTransaction];
     
     [[RBQRealmChangeLogger loggerForRealm:self.inMemoryRealm] willDeleteObject:object];
@@ -182,6 +180,7 @@
 - (void)controllerWillChangeContent:(RBQFetchedResultsController *)controller
 {
     if (self.controllerWillChangeContentExpectation) {
+        
         [self.controllerWillChangeContentExpectation fulfill];
     }
 }
@@ -226,6 +225,7 @@
         self.count ++;
         
         if (self.count == 10) {
+            
             [self.controllerDidChangeObjectExpectation fulfill];
         }
     }
@@ -237,13 +237,16 @@
      forChangeType:(NSFetchedResultsChangeType)type
 {
     if (type == NSFetchedResultsChangeInsert) {
+        
         NSLog(@"Inserting section at %lu", (unsigned long)sectionIndex);
     }
     else if (type == NSFetchedResultsChangeDelete) {
+        
         NSLog(@"Deleting section at %lu", (unsigned long)sectionIndex);
     }
 
     if (self.controllerDidChangeSectionExpectation) {
+        
         [self.controllerDidChangeSectionExpectation fulfill];
     }
 }
@@ -251,6 +254,7 @@
 - (void)controllerDidChangeContent:(RBQFetchedResultsController *)controller
 {
     if (self.controllerDidChangeContentExpectation) {
+        
         [self.controllerDidChangeContentExpectation fulfill];
     }
 }

--- a/RBQFetchedResultsControllerExample/RBQFetchedResultsControllerExampleTests/RBQRealmChangeLoggerTests.m
+++ b/RBQFetchedResultsControllerExample/RBQFetchedResultsControllerExampleTests/RBQRealmChangeLoggerTests.m
@@ -16,30 +16,40 @@
 
 @implementation RBQRealmChangeLoggerTests
 
-- (void)setUp {
+- (void)setUp
+{
     [super setUp];
     // Put setup code here. This method is called before the invocation of each test method in the class.
 }
 
-- (void)tearDown {
+- (void)tearDown
+{
     // Put teardown code here. This method is called after the invocation of each test method in the class.
     [super tearDown];
     
+    RLMRealm *realm = [RLMRealm defaultRealm];
+    
     // Reset Logger status with receive notification from realm
-    [[RLMRealm defaultRealm] transactionWithBlock:^{
-        [[RLMRealm defaultRealm] deleteAllObjects];
+    [realm transactionWithBlock:^{
+        
+        [realm deleteAllObjects];
     }];
 }
 
-- (void)testDidAddObject {
+- (void)testDidAddObject
+{
     RBQRealmChangeLogger *logger = [RBQRealmChangeLogger defaultLogger];
+    
     TestObject *testObject = [[TestObject alloc] init];
+    
     testObject.key = @"key";
     
     XCTAssert(logger.entityChanges.allKeys.count == 0);
     
     [logger didAddObject:testObject];
+    
     NSDictionary *entityChanges = logger.entityChanges;
+    
     RBQEntityChangesObject *entityChangesObject = entityChanges[@"TestObject"];
     
     XCTAssert([entityChangesObject.className isEqualToString:@"TestObject"]);
@@ -48,11 +58,14 @@
     XCTAssert(entityChangesObject.changedSafeObjects.count == 0);
 }
 
-- (void)testDidAddObjects {
+- (void)testDidAddObjects
+{
     RBQRealmChangeLogger *logger = [RBQRealmChangeLogger defaultLogger];
+    
     TestObject *testObject1 = [[TestObject alloc] init];
     TestObject *testObject2 = [[TestObject alloc] init];
     TestObject *testObject3 = [[TestObject alloc] init];
+    
     testObject1.key = @"key1";
     testObject2.key = @"key2";
     testObject3.key = @"key3";
@@ -60,7 +73,9 @@
     XCTAssert(logger.entityChanges.allKeys.count == 0);
     
     [logger didAddObjects:@[testObject1, testObject2, testObject3]];
+    
     NSDictionary *entityChanges = logger.entityChanges;
+    
     RBQEntityChangesObject *entityChangesObject = entityChanges[@"TestObject"];
     
     XCTAssert([entityChangesObject.className isEqualToString:@"TestObject"]);
@@ -69,15 +84,19 @@
     XCTAssert(entityChangesObject.changedSafeObjects.count == 0);
 }
 
-- (void)testWillDeleteObject {
+- (void)testWillDeleteObject
+{
     RBQRealmChangeLogger *logger = [RBQRealmChangeLogger defaultLogger];
+    
     TestObject *testObject = [[TestObject alloc] init];
     testObject.key = @"key";
     
     XCTAssert(logger.entityChanges.allKeys.count == 0);
     
     [logger willDeleteObject:testObject];
+    
     NSDictionary *entityChanges = logger.entityChanges;
+    
     RBQEntityChangesObject *entityChangesObject = entityChanges[@"TestObject"];
     
     XCTAssert([entityChangesObject.className isEqualToString:@"TestObject"]);
@@ -86,11 +105,14 @@
     XCTAssert(entityChangesObject.changedSafeObjects.count == 0);
 }
 
-- (void)testWillDeleteObjects {
+- (void)testWillDeleteObjects
+{
     RBQRealmChangeLogger *logger = [RBQRealmChangeLogger defaultLogger];
+    
     TestObject *testObject1 = [[TestObject alloc] init];
     TestObject *testObject2 = [[TestObject alloc] init];
     TestObject *testObject3 = [[TestObject alloc] init];
+    
     testObject1.key = @"key1";
     testObject2.key = @"key2";
     testObject3.key = @"key3";
@@ -98,7 +120,9 @@
     XCTAssert(logger.entityChanges.allKeys.count == 0);
     
     [logger willDeleteObjects:@[testObject1, testObject2, testObject3]];
+    
     NSDictionary *entityChanges = logger.entityChanges;
+    
     RBQEntityChangesObject *entityChangesObject = entityChanges[@"TestObject"];
     
     XCTAssert([entityChangesObject.className isEqualToString:@"TestObject"]);
@@ -107,15 +131,19 @@
     XCTAssert(entityChangesObject.changedSafeObjects.count == 0);
 }
 
-- (void)testDidChangeObject {
+- (void)testDidChangeObject
+{
     RBQRealmChangeLogger *logger = [RBQRealmChangeLogger defaultLogger];
+    
     TestObject *testObject = [[TestObject alloc] init];
     testObject.key = @"key";
     
     XCTAssert(logger.entityChanges.allKeys.count == 0);
     
     [logger didChangeObject:testObject];
+    
     NSDictionary *entityChanges = logger.entityChanges;
+    
     RBQEntityChangesObject *entityChangesObject = entityChanges[@"TestObject"];
     
     XCTAssert([entityChangesObject.className isEqualToString:@"TestObject"]);
@@ -124,11 +152,14 @@
     XCTAssert(entityChangesObject.changedSafeObjects.count == 1);
 }
 
-- (void)testDidChangeObjects {
+- (void)testDidChangeObjects
+{
     RBQRealmChangeLogger *logger = [RBQRealmChangeLogger defaultLogger];
+    
     TestObject *testObject1 = [[TestObject alloc] init];
     TestObject *testObject2 = [[TestObject alloc] init];
     TestObject *testObject3 = [[TestObject alloc] init];
+    
     testObject1.key = @"key1";
     testObject2.key = @"key2";
     testObject3.key = @"key3";
@@ -136,7 +167,9 @@
     XCTAssert(logger.entityChanges.allKeys.count == 0);
     
     [logger didChangeObjects:@[testObject1, testObject2, testObject3]];
+    
     NSDictionary *entityChanges = logger.entityChanges;
+    
     RBQEntityChangesObject *entityChangesObject = entityChanges[@"TestObject"];
     
     XCTAssert([entityChangesObject.className isEqualToString:@"TestObject"]);


### PR DESCRIPTION
Deprecated:

1. `initWithFetchRequest:sectionNameKeyPath:inMemoryRealmCache:`
2. `objectInRealm:atIndexPath:`

in `RBQFetchedResultsController`

The reason being, when the class was first created In-Memory Realms were not accessible across threads. This has since changed and it is possible to store the in-memory Id (as long as the in-memory Realm is strongly held somewhere) and grab a new instance on a different thread.

As a result, `RBQFetchRequest` now stores the identifier and can retrieve the in-memory Realm when calling its realm property, allowing the FRC to use this, making these methods obsolete.

Furthermore, the external in-memory Realm cache is unnecesary now that passing nil for the cache name internally uses an in-memory Realm. This mirrors `NSFetchedResultsController`.

Finally, added a test for in-memory Realm based `RBQFetchRequest` and cleaned up the recent PR formatting.