### PR TITLE
Make `cacheName` parameter optional

### DIFF
--- a/Swift/FetchedResultsController.swift
+++ b/Swift/FetchedResultsController.swift
@@ -126,7 +126,7 @@ public class FetchedResultsController<T: Object> {
     
     :param: name The name of the cache file to delete. If name is nil, deletes all cache files.
     */
-    public class func deleteCache(cacheName: String) {
+    public class func deleteCache(cacheName: String?) {
         RBQFetchedResultsController.deleteCacheWithName(cacheName)
     }
     


### PR DESCRIPTION
This PR makes the `cacheName` parameter of the `deleteCache` function optional. This was preventing all caches from being deleted in Swift, as you could not pass `nil` to this function.