### PR TITLE
Added a new target for SwiftFetchedResultsController

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "realm/realm-cocoa" "v0.97.0"
+github "realm/realm-cocoa" "v0.98.1"

--- a/Examples/Swift-carthage/RBQFRCSwiftExample.xcodeproj/project.pbxproj
+++ b/Examples/Swift-carthage/RBQFRCSwiftExample.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		A05FA4F51B6185AE0000C9B2 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A05FA4F41B6185AE0000C9B2 /* Images.xcassets */; };
 		A05FA4F81B6185AE0000C9B2 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = A05FA4F61B6185AE0000C9B2 /* LaunchScreen.xib */; };
 		A05FA5041B6185AE0000C9B2 /* RBQFRCSwiftExampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A05FA5031B6185AE0000C9B2 /* RBQFRCSwiftExampleTests.swift */; };
+		A090E5D51C73B3BB0046788B /* SwiftFetchedResultsController.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A090E5D41C73B3B60046788B /* SwiftFetchedResultsController.framework */; };
 		A0AB74621B6C389700923940 /* MainTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0AB74611B6C389700923940 /* MainTableViewController.swift */; };
 		A0BC27BF1C56DA8300306449 /* RBQFetchedResultsController.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A0BC27BA1C56DA7500306449 /* RBQFetchedResultsController.framework */; };
 		A0BC27C21C56DA8D00306449 /* Realm.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A0BC27C01C56DA8D00306449 /* Realm.framework */; };
@@ -27,6 +28,20 @@
 			proxyType = 1;
 			remoteGlobalIDString = A05FA4E71B6185AE0000C9B2;
 			remoteInfo = RBQFRCSwiftExample;
+		};
+		A090E5CF1C73B3B50046788B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A0BC27B41C56DA7500306449 /* RBQFetchedResultsController.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = A090E59F1C73B17B0046788B;
+			remoteInfo = SwiftFetchedResultsController;
+		};
+		A090E5D31C73B3B60046788B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A0BC27B41C56DA7500306449 /* RBQFetchedResultsController.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = A090E5A01C73B17B0046788B;
+			remoteInfo = SwiftFetchedResultsController;
 		};
 		A0BC27B91C56DA7500306449 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -87,6 +102,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A090E5D51C73B3BB0046788B /* SwiftFetchedResultsController.framework in Frameworks */,
 				A0BC27C21C56DA8D00306449 /* Realm.framework in Frameworks */,
 				A0BC27BF1C56DA8300306449 /* RBQFetchedResultsController.framework in Frameworks */,
 				A0BC27C41C56DA8D00306449 /* RealmSwift.framework in Frameworks */,
@@ -175,6 +191,7 @@
 			children = (
 				A0BC27BA1C56DA7500306449 /* RBQFetchedResultsController.framework */,
 				A0BC27BC1C56DA7500306449 /* RBQFetchedResultsController.xctest */,
+				A090E5D41C73B3B60046788B /* SwiftFetchedResultsController.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -194,6 +211,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				A090E5D01C73B3B50046788B /* PBXTargetDependency */,
 				A0BC27BE1C56DA7C00306449 /* PBXTargetDependency */,
 			);
 			name = RBQFRCSwiftExample;
@@ -267,6 +285,13 @@
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
+		A090E5D41C73B3B60046788B /* SwiftFetchedResultsController.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = SwiftFetchedResultsController.framework;
+			remoteRef = A090E5D31C73B3B60046788B /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 		A0BC27BA1C56DA7500306449 /* RBQFetchedResultsController.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
@@ -376,6 +401,11 @@
 			isa = PBXTargetDependency;
 			target = A05FA4E71B6185AE0000C9B2 /* RBQFRCSwiftExample */;
 			targetProxy = A05FA4FE1B6185AE0000C9B2 /* PBXContainerItemProxy */;
+		};
+		A090E5D01C73B3B50046788B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = SwiftFetchedResultsController;
+			targetProxy = A090E5CF1C73B3B50046788B /* PBXContainerItemProxy */;
 		};
 		A0BC27BE1C56DA7C00306449 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/Examples/Swift-carthage/RBQFRCSwiftExample/MainTableViewController.swift
+++ b/Examples/Swift-carthage/RBQFRCSwiftExample/MainTableViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 import Realm
 import RealmSwift
-import RBQFetchedResultsController
+import SwiftFetchedResultsController
 
 // MARK: -
 

--- a/RBQFetchedResultsController.xcodeproj/project.pbxproj
+++ b/RBQFetchedResultsController.xcodeproj/project.pbxproj
@@ -35,17 +35,21 @@
 		A0519B561C56EC9A00307EB5 /* RBQSafeRealmObject.m in Sources */ = {isa = PBXBuildFile; fileRef = A0519B291C56EC9A00307EB5 /* RBQSafeRealmObject.m */; };
 		A0519B591C56EC9A00307EB5 /* RLMObject+SafeObject.h in Headers */ = {isa = PBXBuildFile; fileRef = A0519B2C1C56EC9A00307EB5 /* RLMObject+SafeObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A0519B5A1C56EC9A00307EB5 /* RLMObject+SafeObject.m in Sources */ = {isa = PBXBuildFile; fileRef = A0519B2D1C56EC9A00307EB5 /* RLMObject+SafeObject.m */; };
-		A0519B5B1C56EC9A00307EB5 /* SafeObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0519B2E1C56EC9A00307EB5 /* SafeObject.swift */; };
 		A0519B601C56EC9A00307EB5 /* RLMArray+Utilities.h in Headers */ = {isa = PBXBuildFile; fileRef = A0519B341C56EC9A00307EB5 /* RLMArray+Utilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A0519B611C56EC9A00307EB5 /* RLMArray+Utilities.m in Sources */ = {isa = PBXBuildFile; fileRef = A0519B351C56EC9A00307EB5 /* RLMArray+Utilities.m */; };
 		A0519B621C56EC9A00307EB5 /* RLMObject+Utilities.h in Headers */ = {isa = PBXBuildFile; fileRef = A0519B361C56EC9A00307EB5 /* RLMObject+Utilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A0519B631C56EC9A00307EB5 /* RLMObject+Utilities.m in Sources */ = {isa = PBXBuildFile; fileRef = A0519B371C56EC9A00307EB5 /* RLMObject+Utilities.m */; };
 		A0519B641C56EC9A00307EB5 /* RLMObjectBase+Utilities.h in Headers */ = {isa = PBXBuildFile; fileRef = A0519B381C56EC9A00307EB5 /* RLMObjectBase+Utilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A0519B651C56EC9A00307EB5 /* RLMObjectBase+Utilities.m in Sources */ = {isa = PBXBuildFile; fileRef = A0519B391C56EC9A00307EB5 /* RLMObjectBase+Utilities.m */; };
-		A0519B661C56EC9A00307EB5 /* ChangeLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0519B3B1C56EC9A00307EB5 /* ChangeLogger.swift */; };
-		A0519B671C56EC9A00307EB5 /* FetchedResultsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0519B3C1C56EC9A00307EB5 /* FetchedResultsController.swift */; };
-		A0519B681C56EC9A00307EB5 /* FetchRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0519B3D1C56EC9A00307EB5 /* FetchRequest.swift */; };
-		A0519B691C56EC9A00307EB5 /* Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0519B3E1C56EC9A00307EB5 /* Utilities.swift */; };
+		A090E5B21C73B1CA0046788B /* SafeObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0519B2E1C56EC9A00307EB5 /* SafeObject.swift */; };
+		A090E5C91C73B23F0046788B /* Realm.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6361D7971C4052CC005CD430 /* Realm.framework */; };
+		A090E5CA1C73B2420046788B /* RealmSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6361D7981C4052CC005CD430 /* RealmSwift.framework */; };
+		A090E5CD1C73B2E30046788B /* RBQFetchedResultsController.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6361D7341C4051A8005CD430 /* RBQFetchedResultsController.framework */; };
+		A0F2DB721C73C642002BE6BA /* ChangeLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0F2DB6C1C73C642002BE6BA /* ChangeLogger.swift */; };
+		A0F2DB731C73C642002BE6BA /* FetchedResultsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0F2DB6D1C73C642002BE6BA /* FetchedResultsController.swift */; };
+		A0F2DB741C73C642002BE6BA /* FetchRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0F2DB6E1C73C642002BE6BA /* FetchRequest.swift */; };
+		A0F2DB761C73C642002BE6BA /* SwiftFetchedResultsController.h in Headers */ = {isa = PBXBuildFile; fileRef = A0F2DB701C73C642002BE6BA /* SwiftFetchedResultsController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A0F2DB771C73C642002BE6BA /* Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0F2DB711C73C642002BE6BA /* Utilities.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -55,6 +59,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 6361D7331C4051A8005CD430;
 			remoteInfo = RBQFetchedResultsControllerFramework;
+		};
+		A090E5CB1C73B2DB0046788B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 6361D72B1C4051A8005CD430 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6361D7331C4051A8005CD430;
+			remoteInfo = RBQFetchedResultsController;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -96,10 +107,13 @@
 		A0519B371C56EC9A00307EB5 /* RLMObject+Utilities.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "RLMObject+Utilities.m"; sourceTree = "<group>"; };
 		A0519B381C56EC9A00307EB5 /* RLMObjectBase+Utilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RLMObjectBase+Utilities.h"; sourceTree = "<group>"; };
 		A0519B391C56EC9A00307EB5 /* RLMObjectBase+Utilities.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "RLMObjectBase+Utilities.m"; sourceTree = "<group>"; };
-		A0519B3B1C56EC9A00307EB5 /* ChangeLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChangeLogger.swift; sourceTree = "<group>"; };
-		A0519B3C1C56EC9A00307EB5 /* FetchedResultsController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FetchedResultsController.swift; sourceTree = "<group>"; };
-		A0519B3D1C56EC9A00307EB5 /* FetchRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FetchRequest.swift; sourceTree = "<group>"; };
-		A0519B3E1C56EC9A00307EB5 /* Utilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Utilities.swift; sourceTree = "<group>"; };
+		A090E5A01C73B17B0046788B /* SwiftFetchedResultsController.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftFetchedResultsController.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A0F2DB6C1C73C642002BE6BA /* ChangeLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ChangeLogger.swift; path = RBQFetchedResultsController/Source/Swift/ChangeLogger.swift; sourceTree = SOURCE_ROOT; };
+		A0F2DB6D1C73C642002BE6BA /* FetchedResultsController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FetchedResultsController.swift; path = RBQFetchedResultsController/Source/Swift/FetchedResultsController.swift; sourceTree = SOURCE_ROOT; };
+		A0F2DB6E1C73C642002BE6BA /* FetchRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FetchRequest.swift; path = RBQFetchedResultsController/Source/Swift/FetchRequest.swift; sourceTree = SOURCE_ROOT; };
+		A0F2DB6F1C73C642002BE6BA /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = RBQFetchedResultsController/Source/Swift/Info.plist; sourceTree = SOURCE_ROOT; };
+		A0F2DB701C73C642002BE6BA /* SwiftFetchedResultsController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SwiftFetchedResultsController.h; path = RBQFetchedResultsController/Source/Swift/SwiftFetchedResultsController.h; sourceTree = SOURCE_ROOT; };
+		A0F2DB711C73C642002BE6BA /* Utilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Utilities.swift; path = RBQFetchedResultsController/Source/Swift/Utilities.swift; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -117,6 +131,16 @@
 			buildActionMask = 2147483647;
 			files = (
 				6361D73F1C4051A8005CD430 /* RBQFetchedResultsController.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A090E59C1C73B17B0046788B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A090E5CD1C73B2E30046788B /* RBQFetchedResultsController.framework in Frameworks */,
+				A090E5CA1C73B2420046788B /* RealmSwift.framework in Frameworks */,
+				A090E5C91C73B23F0046788B /* Realm.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -139,6 +163,7 @@
 			children = (
 				6361D7341C4051A8005CD430 /* RBQFetchedResultsController.framework */,
 				6361D73E1C4051A8005CD430 /* RBQFetchedResultsController.xctest */,
+				A090E5A01C73B17B0046788B /* SwiftFetchedResultsController.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -157,15 +182,8 @@
 		6361D74E1C4051ED005CD430 /* Source */ = {
 			isa = PBXGroup;
 			children = (
-				A0519B0E1C56EC9A00307EB5 /* CacheObjects */,
-				A0519B151C56EC9A00307EB5 /* RBQFetchedResultsController.h */,
-				A0519B161C56EC9A00307EB5 /* RBQFetchedResultsController.m */,
-				A0519B171C56EC9A00307EB5 /* RBQFetchRequest.h */,
-				A0519B181C56EC9A00307EB5 /* RBQFetchRequest.m */,
-				A0519B191C56EC9A00307EB5 /* RBQRealmNotificationManager */,
-				A0519B251C56EC9A00307EB5 /* RBQSafeRealmObject */,
-				A0519B301C56EC9A00307EB5 /* RealmUtilities */,
-				A0519B3A1C56EC9A00307EB5 /* Swift */,
+				A0F2DB691C73C472002BE6BA /* RBQFetchedResultsController */,
+				A0F2DB5C1C73C467002BE6BA /* SwiftFetchedResultsController */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -245,17 +263,34 @@
 			path = RBQFetchedResultsController/Source/RealmUtilities;
 			sourceTree = SOURCE_ROOT;
 		};
-		A0519B3A1C56EC9A00307EB5 /* Swift */ = {
+		A0F2DB5C1C73C467002BE6BA /* SwiftFetchedResultsController */ = {
 			isa = PBXGroup;
 			children = (
-				A0519B3B1C56EC9A00307EB5 /* ChangeLogger.swift */,
-				A0519B3C1C56EC9A00307EB5 /* FetchedResultsController.swift */,
-				A0519B3D1C56EC9A00307EB5 /* FetchRequest.swift */,
-				A0519B3E1C56EC9A00307EB5 /* Utilities.swift */,
+				A0F2DB6C1C73C642002BE6BA /* ChangeLogger.swift */,
+				A0F2DB6D1C73C642002BE6BA /* FetchedResultsController.swift */,
+				A0F2DB6E1C73C642002BE6BA /* FetchRequest.swift */,
+				A0F2DB6F1C73C642002BE6BA /* Info.plist */,
+				A0F2DB701C73C642002BE6BA /* SwiftFetchedResultsController.h */,
+				A0F2DB711C73C642002BE6BA /* Utilities.swift */,
 			);
-			name = Swift;
-			path = RBQFetchedResultsController/Source/Swift;
+			name = SwiftFetchedResultsController;
+			path = RBQFetchedResultsController/Source/SwiftFetchedResultsController;
 			sourceTree = SOURCE_ROOT;
+		};
+		A0F2DB691C73C472002BE6BA /* RBQFetchedResultsController */ = {
+			isa = PBXGroup;
+			children = (
+				A0519B0E1C56EC9A00307EB5 /* CacheObjects */,
+				A0519B151C56EC9A00307EB5 /* RBQFetchedResultsController.h */,
+				A0519B161C56EC9A00307EB5 /* RBQFetchedResultsController.m */,
+				A0519B171C56EC9A00307EB5 /* RBQFetchRequest.h */,
+				A0519B181C56EC9A00307EB5 /* RBQFetchRequest.m */,
+				A0519B191C56EC9A00307EB5 /* RBQRealmNotificationManager */,
+				A0519B251C56EC9A00307EB5 /* RBQSafeRealmObject */,
+				A0519B301C56EC9A00307EB5 /* RealmUtilities */,
+			);
+			name = RBQFetchedResultsController;
+			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
@@ -279,6 +314,14 @@
 				A0519B411C56EC9A00307EB5 /* RBQObjectCacheObject.h in Headers */,
 				A0519B3F1C56EC9A00307EB5 /* RBQControllerCacheObject.h in Headers */,
 				A0519B431C56EC9A00307EB5 /* RBQSectionCacheObject.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A090E59D1C73B17B0046788B /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A0F2DB761C73C642002BE6BA /* SwiftFetchedResultsController.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -321,6 +364,25 @@
 			productReference = 6361D73E1C4051A8005CD430 /* RBQFetchedResultsController.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		A090E59F1C73B17B0046788B /* SwiftFetchedResultsController */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A090E5A71C73B17B0046788B /* Build configuration list for PBXNativeTarget "SwiftFetchedResultsController" */;
+			buildPhases = (
+				A090E59B1C73B17B0046788B /* Sources */,
+				A090E59C1C73B17B0046788B /* Frameworks */,
+				A090E59D1C73B17B0046788B /* Headers */,
+				A090E59E1C73B17B0046788B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A090E5CC1C73B2DB0046788B /* PBXTargetDependency */,
+			);
+			name = SwiftFetchedResultsController;
+			productName = SwiftFetchedResultsController;
+			productReference = A090E5A01C73B17B0046788B /* SwiftFetchedResultsController.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -336,6 +398,9 @@
 					};
 					6361D73D1C4051A8005CD430 = {
 						CreatedOnToolsVersion = 7.2;
+					};
+					A090E59F1C73B17B0046788B = {
+						CreatedOnToolsVersion = 7.2.1;
 					};
 				};
 			};
@@ -353,6 +418,7 @@
 			targets = (
 				6361D7331C4051A8005CD430 /* RBQFetchedResultsController */,
 				6361D73D1C4051A8005CD430 /* RBQFetchedResultsControllerTests */,
+				A090E59F1C73B17B0046788B /* SwiftFetchedResultsController */,
 			);
 		};
 /* End PBXProject section */
@@ -373,6 +439,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A090E59E1C73B17B0046788B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -382,10 +455,7 @@
 			files = (
 				A0519B611C56EC9A00307EB5 /* RLMArray+Utilities.m in Sources */,
 				A0519B4C1C56EC9A00307EB5 /* RLMRealm+Notifications.m in Sources */,
-				A0519B691C56EC9A00307EB5 /* Utilities.swift in Sources */,
 				A0519B651C56EC9A00307EB5 /* RLMObjectBase+Utilities.m in Sources */,
-				A0519B5B1C56EC9A00307EB5 /* SafeObject.swift in Sources */,
-				A0519B661C56EC9A00307EB5 /* ChangeLogger.swift in Sources */,
 				A0519B441C56EC9A00307EB5 /* RBQSectionCacheObject.m in Sources */,
 				A0519B4A1C56EC9A00307EB5 /* RLMObject+Notifications.m in Sources */,
 				A0519B481C56EC9A00307EB5 /* RBQFetchRequest.m in Sources */,
@@ -396,8 +466,6 @@
 				A0519B5A1C56EC9A00307EB5 /* RLMObject+SafeObject.m in Sources */,
 				A0519B461C56EC9A00307EB5 /* RBQFetchedResultsController.m in Sources */,
 				A0519B401C56EC9A00307EB5 /* RBQControllerCacheObject.m in Sources */,
-				A0519B681C56EC9A00307EB5 /* FetchRequest.swift in Sources */,
-				A0519B671C56EC9A00307EB5 /* FetchedResultsController.swift in Sources */,
 				A0519B4E1C56EC9A00307EB5 /* RLMResults+Notifications.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -410,6 +478,18 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A090E59B1C73B17B0046788B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A0F2DB741C73C642002BE6BA /* FetchRequest.swift in Sources */,
+				A090E5B21C73B1CA0046788B /* SafeObject.swift in Sources */,
+				A0F2DB731C73C642002BE6BA /* FetchedResultsController.swift in Sources */,
+				A0F2DB771C73C642002BE6BA /* Utilities.swift in Sources */,
+				A0F2DB721C73C642002BE6BA /* ChangeLogger.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -417,6 +497,11 @@
 			isa = PBXTargetDependency;
 			target = 6361D7331C4051A8005CD430 /* RBQFetchedResultsController */;
 			targetProxy = 6361D7401C4051A8005CD430 /* PBXContainerItemProxy */;
+		};
+		A090E5CC1C73B2DB0046788B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 6361D7331C4051A8005CD430 /* RBQFetchedResultsController */;
+			targetProxy = A090E5CB1C73B2DB0046788B /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -574,6 +659,48 @@
 			};
 			name = Release;
 		};
+		A090E5A51C73B17B0046788B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = RBQFetchedResultsController/Source/Swift/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.Roobiq.SwiftFetchedResultsController;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		A090E5A61C73B17B0046788B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = RBQFetchedResultsController/Source/Swift/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.Roobiq.SwiftFetchedResultsController;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -600,6 +727,15 @@
 			buildConfigurations = (
 				6361D74C1C4051A8005CD430 /* Debug */,
 				6361D74D1C4051A8005CD430 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A090E5A71C73B17B0046788B /* Build configuration list for PBXNativeTarget "SwiftFetchedResultsController" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A090E5A51C73B17B0046788B /* Debug */,
+				A090E5A61C73B17B0046788B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/RBQFetchedResultsController.xcodeproj/xcshareddata/xcschemes/SwiftFetchedResultsController.xcscheme
+++ b/RBQFetchedResultsController.xcodeproj/xcshareddata/xcschemes/SwiftFetchedResultsController.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0720"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A090E59F1C73B17B0046788B"
+               BuildableName = "SwiftFetchedResultsController.framework"
+               BlueprintName = "SwiftFetchedResultsController"
+               ReferencedContainer = "container:RBQFetchedResultsController.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A090E59F1C73B17B0046788B"
+            BuildableName = "SwiftFetchedResultsController.framework"
+            BlueprintName = "SwiftFetchedResultsController"
+            ReferencedContainer = "container:RBQFetchedResultsController.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A090E59F1C73B17B0046788B"
+            BuildableName = "SwiftFetchedResultsController.framework"
+            BlueprintName = "SwiftFetchedResultsController"
+            ReferencedContainer = "container:RBQFetchedResultsController.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/RBQFetchedResultsController/Source/Swift/Info.plist
+++ b/RBQFetchedResultsController/Source/Swift/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/RBQFetchedResultsController/Source/Swift/SwiftFetchedResultsController.h
+++ b/RBQFetchedResultsController/Source/Swift/SwiftFetchedResultsController.h
@@ -1,0 +1,20 @@
+//
+//  SwiftFetchedResultsController.h
+//  SwiftFetchedResultsController
+//
+//  Created by Adam Fish on 2/16/16.
+//  Copyright © 2016 Atai Barkai. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for SwiftFetchedResultsController.
+FOUNDATION_EXPORT double SwiftFetchedResultsControllerVersionNumber;
+
+//! Project version string for SwiftFetchedResultsController.
+FOUNDATION_EXPORT const unsigned char SwiftFetchedResultsControllerVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <SwiftFetchedResultsController/PublicHeader.h>
+@import RBQFetchedResultsController;
+
+


### PR DESCRIPTION
This separates RBQFetchedResultsController (Obj-C) from SwiftFetchedResultsController. Carthage now builds both targets, so any projects that depend on `import SwiftFetchedResultsController` should work fine.