### PR TITLE
Removes encryption from the FRC cache if default config is using it

### DIFF
--- a/RBQFetchedResultsController/Source/RBQFetchedResultsController.m
+++ b/RBQFetchedResultsController/Source/RBQFetchedResultsController.m
@@ -261,7 +261,10 @@ static void * RBQArrayFetchRequestContext = &RBQArrayFetchRequestContext;
 // Create Realm instance for cache name
 + (RLMRealm *)realmForCacheName:(NSString *)cacheName
 {
-    return [RLMRealm realmWithPath:[RBQFetchedResultsController cachePathWithName:cacheName]];
+    RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
+    config.path = [RBQFetchedResultsController cachePathWithName:cacheName];
+    config.encryptionKey = nil;
+    return [RLMRealm realmWithConfiguration:config error:nil];
 }
 
 //  Create a file path for Realm cache with a given name
@@ -1814,6 +1817,7 @@ static void * RBQArrayFetchRequestContext = &RBQArrayFetchRequestContext;
     }
     else {
         RLMRealmConfiguration *inMemoryConfiguration = [RLMRealmConfiguration defaultConfiguration];
+        inMemoryConfiguration.encryptionKey = nil;
         inMemoryConfiguration.inMemoryIdentifier = [self nameForFetchRequest:self.fetchRequest];
         
         RLMRealm *realm = [RLMRealm realmWithConfiguration:inMemoryConfiguration


### PR DESCRIPTION
This fixes the issue where the FRC cache will use encryption if the default config is setup for it.

However, I am not sure this is the right solution, since if the default config is to encrypt, the FRC cache should be too.