### PR TITLE
Fix typo Peform in updateFetchRequest:sectionNameKeyPath:andPerformFe…

### DIFF
--- a/RBQFetchedResultsController/Source/RBQFetchedResultsController.h
+++ b/RBQFetchedResultsController/Source/RBQFetchedResultsController.h
@@ -270,6 +270,6 @@
  */
 - (void)updateFetchRequest:(nonnull RBQFetchRequest *)fetchRequest
         sectionNameKeyPath:(nullable NSString *)sectionNameKeyPath
-            andPeformFetch:(BOOL)performFetch;
+            andPerformFetch:(BOOL)performFetch;
 
 @end

--- a/RBQFetchedResultsController/Source/RBQFetchedResultsController.m
+++ b/RBQFetchedResultsController/Source/RBQFetchedResultsController.m
@@ -571,7 +571,7 @@ static void * RBQArrayFetchRequestContext = &RBQArrayFetchRequestContext;
 
 - (void)updateFetchRequest:(RBQFetchRequest *)fetchRequest
         sectionNameKeyPath:(NSString *)sectionNameKeyPath
-            andPeformFetch:(BOOL)performFetch
+            andPerformFetch:(BOOL)performFetch
 {
     @synchronized(self) {
         // Turn off change notifications since we are replacing fetch request


### PR DESCRIPTION
This commit fixed the typo on function name updateFetchRequest:sectionNameKeyPath:andPeformFetch.

Before fix  ...andPeformFetch, after ...andPerformFetch.