### PR TITLE
Add controllerWillPerformFetch and controllerDidPerformFetch as delegate methods

### DIFF
--- a/RBQFetchedResultsController/Source/RBQFetchedResultsController.h
+++ b/RBQFetchedResultsController/Source/RBQFetchedResultsController.h
@@ -98,16 +98,16 @@
 - (void)controllerDidChangeContent:(nonnull RBQFetchedResultsController *)controller;
 
 /**
- *  This method is called before the controller performing fetch.
+ *  This method is called before the controller performs the fetch.
  *
- *  @param controller controller instance that performing fetch
+ *  @param controller controller instance that will perform the fetch
  */
 - (void)controllerWillPerformFetch:(nonnull RBQFetchedResultsController *)controller;
 
 /**
- *  This method is called when the controller successfully fetching objects. It will not executed if the fetchRequest is nil.
+ *  This method is called after the controller successfully fetches objects. It will not be called if the fetchRequest is nil.
  *
- *  @param controller controller instance that performing fetch
+ *  @param controller controller instance that performed the fetch
  */
 - (void)controllerDidPerformFetch:(nonnull RBQFetchedResultsController *)controller;
 

--- a/RBQFetchedResultsController/Source/RBQFetchedResultsController.h
+++ b/RBQFetchedResultsController/Source/RBQFetchedResultsController.h
@@ -97,6 +97,20 @@
  */
 - (void)controllerDidChangeContent:(nonnull RBQFetchedResultsController *)controller;
 
+/**
+ *  This method is called before the controller performing fetch.
+ *
+ *  @param controller controller instance that performing fetch
+ */
+- (void)controllerWillPerformFetch:(nonnull RBQFetchedResultsController *)controller;
+
+/**
+ *  This method is called when the controller successfully fetching objects. It will not executed if the fetchRequest is nil.
+ *
+ *  @param controller controller instance that performing fetch
+ */
+- (void)controllerDidPerformFetch:(nonnull RBQFetchedResultsController *)controller;
+
 @end
 
 #pragma mark - RBQFetchedResultsController

--- a/RBQFetchedResultsController/Source/RBQFetchedResultsController.m
+++ b/RBQFetchedResultsController/Source/RBQFetchedResultsController.m
@@ -370,6 +370,10 @@ static void * RBQArrayFetchRequestContext = &RBQArrayFetchRequestContext;
 
 - (BOOL)performFetch
 {
+    if ([self.delegate respondsToSelector:@selector(controllerWillPerformFetch:)]) {
+        [self.delegate controllerWillPerformFetch:self];
+    }
+    
     if (self.fetchRequest) {
         
         if (self.cacheName) {
@@ -387,6 +391,10 @@ static void * RBQArrayFetchRequestContext = &RBQArrayFetchRequestContext;
         
         // Only register for changes after the cache was created!
         [self registerChangeNotifications];
+        
+        if ([self.delegate respondsToSelector:@selector(controllerDidPerformFetch:)]) {
+            [self.delegate controllerDidPerformFetch:self];
+        }
         
         return YES;
     }


### PR DESCRIPTION
This delegate method is necessary for me because I defer the performFetch some time after the view did appear. The controllerDidPerformFetch method is also necessary for initial fetching because controllerDidChangeContent is not called then.