### PR TITLE
fix primary key problem

### DIFF
--- a/RBQFetchedResultsController/Source/CacheObjects/RBQObjectCacheObject.m
+++ b/RBQFetchedResultsController/Source/CacheObjects/RBQObjectCacheObject.m
@@ -101,7 +101,7 @@
         return [realm objectWithClassName:cacheObject.className forPrimaryKey:cacheObject.primaryKeyStringValue];
     }
     else if (cacheObject.primaryKeyType == RLMPropertyTypeInt) {
-        NSNumber *numberFromString = @(cacheObject.primaryKeyStringValue.integerValue);
+        NSNumber *numberFromString = @(cacheObject.primaryKeyStringValue.longLongValue);
         
         return [realm objectWithClassName:cacheObject.className forPrimaryKey:numberFromString];
     }

--- a/SwiftFetchedResultsController.podspec
+++ b/SwiftFetchedResultsController.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.author       = { "Roobiq" => "support@roobiq.com" }
   s.social_media_url   = "http://twitter.com/Roobiq"
   s.platform     = :ios, "8.0"
-  s.source       = { :git => "https://github.com/Roobiq/RBQFetchedResultsController.git", :tag => "v#{s.version}", :submodules => true }
+  s.source       = { :git => "https://github.com/zenghaojim33/ABFRealmTableViewController.git", :tag => "v#{s.version}", :submodules => true }
   s.source_files  = "RBQFetchedResultsController/Source/Swift/*.{h,swift}", "RBQFetchedResultsController/Source/RBQSafeRealmObject/*.{swift}"
   s.requires_arc = true
   s.dependency "RealmSwift", ">=0.96"

--- a/SwiftFetchedResultsController.podspec
+++ b/SwiftFetchedResultsController.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.author       = { "Roobiq" => "support@roobiq.com" }
   s.social_media_url   = "http://twitter.com/Roobiq"
   s.platform     = :ios, "8.0"
-  s.source       = { :git => "https://github.com/zenghaojim33/RBQFetchedResultsController.git", :tag => "v#{s.version}", :submodules => true }
+  s.source       = { :git => "https://github.com/Roobiq/RBQFetchedResultsController.git", :tag => "v#{s.version}", :submodules => true }
   s.source_files  = "RBQFetchedResultsController/Source/Swift/*.{h,swift}", "RBQFetchedResultsController/Source/RBQSafeRealmObject/*.{swift}"
   s.requires_arc = true
   s.dependency "RealmSwift", ">=0.96"

--- a/SwiftFetchedResultsController.podspec
+++ b/SwiftFetchedResultsController.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.author       = { "Roobiq" => "support@roobiq.com" }
   s.social_media_url   = "http://twitter.com/Roobiq"
   s.platform     = :ios, "8.0"
-  s.source       = { :git => "https://github.com/zenghaojim33/ABFRealmTableViewController.git", :tag => "v#{s.version}", :submodules => true }
+  s.source       = { :git => "https://github.com/zenghaojim33/RBQFetchedResultsController.git", :tag => "v#{s.version}", :submodules => true }
   s.source_files  = "RBQFetchedResultsController/Source/Swift/*.{h,swift}", "RBQFetchedResultsController/Source/RBQSafeRealmObject/*.{swift}"
   s.requires_arc = true
   s.dependency "RealmSwift", ">=0.96"


### PR DESCRIPTION
If the object's primary key is a large number string, `integerValue`(instead of `longLongValue`) conversion under 32bit devices will cause precision lose so that the object can not be retrieved properly.