### PR TITLE
Add missing required protocol methods

### DIFF
--- a/Examples/Swift-carthage/RBQFRCSwiftExample/MainTableViewController.swift
+++ b/Examples/Swift-carthage/RBQFRCSwiftExample/MainTableViewController.swift
@@ -295,4 +295,7 @@ extension MainTableViewController: FetchedResultsControllerDelegate {
     func controllerDidChangeContent<T : Object>(controller: FetchedResultsController<T>) {
         self.tableView.endUpdates()
     }
+
+    func controllerWillPerformFetch<T : Object>(controller: FetchedResultsController<T>) {}
+    func controllerDidPerformFetch<T : Object>(controller: FetchedResultsController<T>) {}
 }

--- a/Examples/Swift-cocoapods/RBQFRCSwiftExample/MainTableViewController.swift
+++ b/Examples/Swift-cocoapods/RBQFRCSwiftExample/MainTableViewController.swift
@@ -295,4 +295,7 @@ extension MainTableViewController: FetchedResultsControllerDelegate {
     func controllerDidChangeContent<T : Object>(controller: FetchedResultsController<T>) {
         self.tableView.endUpdates()
     }
+
+    func controllerWillPerformFetch<T : Object>(controller: FetchedResultsController<T>) {}
+    func controllerDidPerformFetch<T : Object>(controller: FetchedResultsController<T>) {}
 }

--- a/Examples/Swift/RBQFRCSwiftExample/MainTableViewController.swift
+++ b/Examples/Swift/RBQFRCSwiftExample/MainTableViewController.swift
@@ -294,4 +294,7 @@ extension MainTableViewController: FetchedResultsControllerDelegate {
     func controllerDidChangeContent<T : Object>(controller: FetchedResultsController<T>) {
         self.tableView.endUpdates()
     }
+
+    func controllerWillPerformFetch<T : Object>(controller: FetchedResultsController<T>) {}
+    func controllerDidPerformFetch<T : Object>(controller: FetchedResultsController<T>) {}
 }

--- a/RBQFetchedResultsController/Source/Swift/FetchedResultsController.swift
+++ b/RBQFetchedResultsController/Source/Swift/FetchedResultsController.swift
@@ -106,6 +106,22 @@ public protocol FetchedResultsControllerDelegate: class {
     :param: controller controller instance that noticed the change on its fetched objects
     */
     func controllerDidChangeContent<T: Object>(controller: FetchedResultsController<T>)
+
+
+
+    /**
+    This method is called before the controller performs the fetch.
+
+     :param: controller controller instance that will perform the fetch
+     */
+    func controllerWillPerformFetch<T: Object>(controller: FetchedResultsController<T>)
+
+    /**
+    This method is called after the controller successfully fetches objects. It will not be called if the fetchRequest is nil.
+
+    :param: controller controller instance that performed the fetch
+    */
+    func controllerDidPerformFetch<T: Object>(controller: FetchedResultsController<T>)
 }
 
 /**
@@ -383,6 +399,21 @@ extension FetchedResultsController: DelegateProxyProtocol {
             delegate.controllerDidChangeContent(self)
         }
     }
+
+    func controllerWillPerformFetch(controller: RBQFetchedResultsController!) {
+        if let delegate = self.delegate {
+            delegate.controllerWillPerformFetch(self)
+        }
+
+    }
+
+    func controllerDidPerformFetch(controller: RBQFetchedResultsController!) {
+        if let delegate = self.delegate {
+
+            delegate.controllerDidPerformFetch(self)
+        }
+
+    }
 }
 
 // Internal Proxy To Manage Converting The Objc Delegate
@@ -394,6 +425,10 @@ internal protocol DelegateProxyProtocol: class {
     func controller(controller: RBQFetchedResultsController!, didChangeSection section: RBQFetchedResultsSectionInfo!, atIndex sectionIndex: UInt, forChangeType type: NSFetchedResultsChangeType)
     
     func controllerDidChangeContent(controller: RBQFetchedResultsController!)
+
+    func controllerWillPerformFetch(controller: RBQFetchedResultsController!)
+
+    func controllerDidPerformFetch(controller: RBQFetchedResultsController!)
 }
 
 // Internal Proxy To Manage Converting The Objc Delegate
@@ -423,4 +458,14 @@ internal class DelegateProxy: NSObject, RBQFetchedResultsControllerDelegate {
     @objc func controllerDidChangeContent(controller: RBQFetchedResultsController) {
         self.delegate?.controllerDidChangeContent(controller)
     }
+
+
+    @objc func controllerWillPerformFetch(controller: RBQFetchedResultsController) {
+        self.delegate?.controllerWillPerformFetch(controller)
+    }
+
+    @objc func controllerDidPerformFetch(controller: RBQFetchedResultsController) {
+        self.delegate?.controllerDidPerformFetch(controller)
+    }
+
 }


### PR DESCRIPTION
Required method `controllerWillPerformFetch` and `controllerDidPerformFetch` are added in 7940731cf120f8eae80252a905d078ca093ccfbf , but those were not implemented in Swift version. That caused build error.

Fixes #93