### PR TITLE
Optional logging

### DIFF
--- a/RBQFetchedResultsController/Source/RBQFetchedResultsController.h
+++ b/RBQFetchedResultsController/Source/RBQFetchedResultsController.h
@@ -122,6 +122,8 @@
  */
 @interface RBQFetchedResultsController : NSObject
 
+@property (nonatomic) bool logging;
+
 /**
  *  The fetch request for the controller
  */

--- a/RBQFetchedResultsController/Source/RBQFetchedResultsController.m
+++ b/RBQFetchedResultsController/Source/RBQFetchedResultsController.m
@@ -373,6 +373,10 @@ static void * RBQArrayFetchRequestContext = &RBQArrayFetchRequestContext;
         _cacheName = name;
         _fetchRequest = fetchRequest;
         _sectionNameKeyPath = sectionNameKeyPath;
+		
+#ifdef DEBUG
+		_logging = true;
+#endif
     }
     
     return self;
@@ -823,14 +827,15 @@ static void * RBQArrayFetchRequestContext = &RBQArrayFetchRequestContext;
         RBQDerivedChangesObject *derivedChanges = [self deriveChangesWithChangeSets:changeSets
                                                                      sectionChanges:sectionChanges
                                                                               state:state];
-#ifdef DEBUG
-        NSLog(@"%lu Derived Inserted Sections",(unsigned long)derivedChanges.insertedSectionChanges.count);
-        NSLog(@"%lu Derived Deleted Sections",(unsigned long)derivedChanges.deletedSectionChanges.count);
-        NSLog(@"%lu Derived Added Objects",(unsigned long)derivedChanges.insertedObjectChanges.count);
-        NSLog(@"%lu Derived Deleted Objects",(unsigned long)derivedChanges.deletedObjectChanges.count);
-        NSLog(@"%lu Derived Moved Objects",(unsigned long)derivedChanges.movedObjectChanges.count);
-#endif
-        
+
+		if(self.logging) {
+			NSLog(@"%lu Derived Inserted Sections",(unsigned long)derivedChanges.insertedSectionChanges.count);
+			NSLog(@"%lu Derived Deleted Sections",(unsigned long)derivedChanges.deletedSectionChanges.count);
+			NSLog(@"%lu Derived Added Objects",(unsigned long)derivedChanges.insertedObjectChanges.count);
+			NSLog(@"%lu Derived Deleted Objects",(unsigned long)derivedChanges.deletedObjectChanges.count);
+			NSLog(@"%lu Derived Moved Objects",(unsigned long)derivedChanges.movedObjectChanges.count);
+		}
+		
         // Apply Derived Changes To Cache
         [self applyDerivedChangesToCache:derivedChanges
                                    state:state];

--- a/RBQFetchedResultsController/Source/Swift/FetchedResultsController.swift
+++ b/RBQFetchedResultsController/Source/Swift/FetchedResultsController.swift
@@ -208,7 +208,7 @@ public class FetchedResultsController<T: Object> {
     
     // MARK: Properties
 	
-	public var debug: Bool {
+	public var logging: Bool {
 		get {
 			return self.rbqFetchedResultsController.logging
 		}

--- a/RBQFetchedResultsController/Source/Swift/FetchedResultsController.swift
+++ b/RBQFetchedResultsController/Source/Swift/FetchedResultsController.swift
@@ -207,6 +207,16 @@ public class FetchedResultsController<T: Object> {
     }
     
     // MARK: Properties
+	
+	public var debug: Bool {
+		get {
+			return self.rbqFetchedResultsController.logging
+		}
+		
+		set {
+			self.rbqFetchedResultsController.logging = newValue
+		}
+	}
     
     /// The fetch request for the controller
     public let fetchRequest: FetchRequest<T>


### PR DESCRIPTION
Added ability to disable object changes logging at runtime (it is still enabled by default for Debug configuration).
Also it is useful when there are many results controllers in the app and developer wants to debug only some of them.