### PR TITLE
Fixed a crash when deleting objects after deleting a section.

### DIFF
--- a/RBQFetchedResultsController/Source/RBQFetchedResultsController.m
+++ b/RBQFetchedResultsController/Source/RBQFetchedResultsController.m
@@ -872,12 +872,11 @@ static void * RBQArrayFetchRequestContext = &RBQArrayFetchRequestContext;
         for (RBQSectionChangeObject *sectionChange in sectionChanges) {
             
             if (sectionChange.changeType == NSFetchedResultsChangeDelete) {
-                
 #ifdef DEBUG
                 NSAssert(sectionChange.previousIndex.unsignedIntegerValue < state.cache.sections.count, @"Attemting to delete index that is already gone!");
 #endif
                 // Remove the section from Realm cache
-                [state.cache.sections removeObjectAtIndex:sectionChange.previousIndex.unsignedIntegerValue];
+                [state.cache.realm deleteObject:sectionChange.section];
             }
             else if (sectionChange.changeType == NSFetchedResultsChangeInsert) {
                 


### PR DESCRIPTION
This fixes the crash reported in #116. 

The old implementation only removed the deleted section from the cached `RLMArray` instead of deleting it from the cached Realm, which in turn also removes it from the `RLMArray`.