### PR TITLE
section support use non-string value

### DIFF
--- a/RBQFetchedResultsController/Source/CacheObjects/RBQObjectCacheObject.h
+++ b/RBQFetchedResultsController/Source/CacheObjects/RBQObjectCacheObject.h
@@ -33,8 +33,8 @@
 /**
  *  Primary key type (use to convert the string value if necessary)
  *
- * @warning Only supports RLMPropertyTypeInt and RLMPropertyTypeString, which are the only
- * supported Realm primary key types as of v0.90.5.
+ * @warning Only supports RLMPropertyTypeInt ,RLMPropertyTypeString and RLMPropertyTypeDate, which are the only
+ * supported Realm primary key types as of v1.0.
  */
 @property NSInteger primaryKeyType;
 

--- a/RBQFetchedResultsController/Source/CacheObjects/RBQObjectCacheObject.m
+++ b/RBQFetchedResultsController/Source/CacheObjects/RBQObjectCacheObject.m
@@ -37,6 +37,12 @@
     else if (cacheObject.primaryKeyType == RLMPropertyTypeInt) {
         cacheObject.primaryKeyStringValue = ((NSNumber *)primaryKeyValue).stringValue;
     }
+    else if (cacheObject.primaryKeyType == RLMPropertyTypeDate) {
+        NSString *dateString = [NSDateFormatter localizedStringFromDate:(NSDate *)primaryKeyValue
+                                                              dateStyle:NSDateFormatterMediumStyle
+                                                              timeStyle:NSDateFormatterFullStyle];
+        cacheObject.primaryKeyStringValue = dateString;
+    }
     else {
         @throw([self unsupportedPrimaryKeyTypeException]);
     }
@@ -57,6 +63,12 @@
     }
     else if (cacheObject.primaryKeyType == RLMPropertyTypeInt) {
         cacheObject.primaryKeyStringValue = ((NSNumber *)safeObject.primaryKeyValue).stringValue;
+    }
+    else if (cacheObject.primaryKeyType == RLMPropertyTypeDate) {
+        NSString *dateString = [NSDateFormatter localizedStringFromDate:(NSDate *)safeObject.primaryKeyValue
+                                                              dateStyle:NSDateFormatterMediumStyle
+                                                              timeStyle:NSDateFormatterFullStyle];
+        cacheObject.primaryKeyStringValue = dateString;
     }
     else {
         @throw([self unsupportedPrimaryKeyTypeException]);
@@ -86,6 +98,14 @@
             return [RBQObjectCacheObject objectInRealm:realm
                                          forPrimaryKey:primaryKeyStringValue];
         }
+        else if (primaryKeyType == RLMPropertyTypeDate) {
+            NSString *primaryKeyStringValue = [NSDateFormatter localizedStringFromDate:(NSDate *)primaryKeyValue
+                                                                  dateStyle:NSDateFormatterMediumStyle
+                                                                  timeStyle:NSDateFormatterFullStyle];
+            return [RBQObjectCacheObject objectInRealm:realm
+                                         forPrimaryKey:primaryKeyStringValue];
+        }
+
         else {
             @throw([self unsupportedPrimaryKeyTypeException]);
         }
@@ -105,6 +125,11 @@
         NSNumber *numberFromString = @(cacheObject.primaryKeyStringValue.longLongValue);
         
         return [realm objectWithClassName:cacheObject.className forPrimaryKey:numberFromString];
+    }
+    else if (cacheObject.primaryKeyType == RLMPropertyTypeDate) {
+        NSDate *dateFromKey = (NSDate *)cacheObject.primaryKeyValue;
+        
+        return [realm objectWithClassName:cacheObject.className forPrimaryKey:dateFromKey];
     }
     else {
         @throw ([self unsupportedPrimaryKeyTypeException]);
@@ -136,7 +161,14 @@
         
         return numberFromString;
     }
-    
+    if (self.primaryKeyType == RLMPropertyTypeDate) {
+        NSDateFormatter *format = [[NSDateFormatter alloc] init];
+        format.dateStyle = NSDateFormatterMediumStyle;
+        format.timeStyle = NSDateFormatterFullStyle;
+        NSDate *dateFromString = [format dateFromString:self.primaryKeyStringValue];;
+        
+        return dateFromString;
+    }
     return self.primaryKeyStringValue;
 }
 
@@ -153,6 +185,10 @@
              object.primaryKeyType == RLMPropertyTypeInt) {
         
         return self.primaryKeyStringValue.integerValue == object.primaryKeyStringValue.integerValue;
+    }
+    else if (self.primaryKeyType == RLMPropertyTypeDate &&
+             object.primaryKeyType == RLMPropertyTypeDate) {
+        return [(NSDate *)self.primaryKeyValue isEqualToDate:(NSDate *)object.primaryKeyValue];
     }
     else {
         return [super isEqual:object];

--- a/RBQFetchedResultsController/Source/CacheObjects/RBQSectionCacheObject.h
+++ b/RBQFetchedResultsController/Source/CacheObjects/RBQSectionCacheObject.h
@@ -45,7 +45,17 @@ RLM_ARRAY_TYPE(RBQObjectCacheObject)
  *
  *  @return A new instance of RBQSectionCacheObject
  */
-+ (instancetype)cacheWithName:(NSString *)name;
++ (instancetype)cacheWithName:(NSString *)name keyType:(RLMPropertyType)keyType;
+
+/**
+ *  key type (use to convert the string value if necessary)
+ *
+ * @warning Only supports RLMPropertyTypeInt ,RLMPropertyTypeString and RLMPropertyTypeDate which are the only
+ * supported Realm primary key types as of v1.0.
+ */
+@property NSInteger keyType;
+
+- (id)value;
 
 @end
 

--- a/RBQFetchedResultsController/Source/CacheObjects/RBQSectionCacheObject.m
+++ b/RBQFetchedResultsController/Source/CacheObjects/RBQSectionCacheObject.m
@@ -10,11 +10,11 @@
 
 @implementation RBQSectionCacheObject
 
-+ (instancetype)cacheWithName:(NSString *)name
++ (instancetype)cacheWithName:(NSString *)name keyType:(RLMPropertyType)keyType
 {
     RBQSectionCacheObject *section = [[RBQSectionCacheObject alloc] init];
     section.name = name;
-    
+    section.keyType = keyType;
     return section;
 }
 
@@ -43,5 +43,24 @@
 {
     return [self isEqualToObject:object];
 }
+
+- (id)value
+{
+    if (self.keyType == RLMPropertyTypeInt) {
+        NSNumber *numberFromString = @(self.name.integerValue);
+        
+        return numberFromString;
+    }
+    if (self.keyType == RLMPropertyTypeDate) {
+        NSDateFormatter *format = [[NSDateFormatter alloc] init];
+        format.dateStyle = NSDateFormatterMediumStyle;
+        format.timeStyle = NSDateFormatterFullStyle;
+        NSDate *dateFromString = [format dateFromString:self.name];
+        
+        return dateFromString;
+    }
+    return self.name;
+}
+
 
 @end

--- a/RBQFetchedResultsController/Source/RBQFetchedResultsController.h
+++ b/RBQFetchedResultsController/Source/RBQFetchedResultsController.h
@@ -32,9 +32,9 @@
 @property (nonatomic, readonly, nonnull) id<RLMCollection> objects;
 
 /**
- *  The name of the section.
+ *  The value of the section.
  */
-@property (nonatomic, readonly, nonnull) NSString *name;
+@property (nonatomic, readonly, nonnull) id value;
 
 @end
 
@@ -135,6 +135,11 @@
 @property (nonatomic, readonly, nullable) NSString *sectionNameKeyPath;
 
 /**
+ *  The section name key path used to create the sections. Can be nil if no sections.
+ */
+@property (nonatomic, readonly, assign) RLMPropertyType sectionNameKeyType;
+
+/**
  *  The delegate to pass the index path and section changes to.
  */
 @property (nonatomic, weak, nullable) id <RBQFetchedResultsControllerDelegate> delegate;
@@ -189,6 +194,7 @@
  */
 - (nonnull id)initWithFetchRequest:(nonnull RBQFetchRequest *)fetchRequest
                 sectionNameKeyPath:(nullable NSString *)sectionNameKeyPath
+                sectionNameKeyType:(RLMPropertyType)sectionNameKeyType
                          cacheName:(nullable NSString *)name;
 
 /**
@@ -222,13 +228,13 @@
 - (NSInteger)numberOfSections;
 
 /**
- *  Method to retrieve the title for a given section index
+ *  Method to retrieve the object for a given section index
  *
  *  @param section section index
  *
- *  @return The title of the section
+ *  @return The object of the section
  */
-- (nonnull NSString *)titleForHeaderInSection:(NSInteger)section;
+- (id _Nullable )objectForHeaderInSection:(NSInteger)section;
 
 /**
  *  Method to retrieve the section index given a section name

--- a/RBQFetchedResultsController/Source/RBQFetchedResultsController.h
+++ b/RBQFetchedResultsController/Source/RBQFetchedResultsController.h
@@ -194,6 +194,23 @@
  */
 - (nonnull id)initWithFetchRequest:(nonnull RBQFetchRequest *)fetchRequest
                 sectionNameKeyPath:(nullable NSString *)sectionNameKeyPath
+                         cacheName:(nullable NSString *)name;
+
+/**
+ *  Constructor method to initialize the controller
+ *
+ *  @warning Specify a cache name if deletion of the cache later on is necessary
+ *
+ *  @param fetchRequest       the RBQFetchRequest for the controller
+ *  @param sectionNameKeyPath A key path on result objects that returns the section name. Pass nil to indicate that the controller should generate a single section. If this key path is not the same as that specified by the first sort descriptor in fetchRequest, they must generate the same relative orderings.
+ *  @param sectionNameKeyType the PropertyType of key path on result objects that returns the section name.
+ *  @param name               the cache name (if nil, cache will not be persisted and built using an in-memory Realm)
+ *
+ *  @return A new instance of RBQFetchedResultsController
+ */
+
+- (nonnull id)initWithFetchRequest:(nonnull RBQFetchRequest *)fetchRequest
+                sectionNameKeyPath:(nullable NSString *)sectionNameKeyPath
                 sectionNameKeyType:(RLMPropertyType)sectionNameKeyType
                          cacheName:(nullable NSString *)name;
 

--- a/RBQFetchedResultsController/Source/RBQFetchedResultsController.m
+++ b/RBQFetchedResultsController/Source/RBQFetchedResultsController.m
@@ -362,6 +362,13 @@ static void * RBQArrayFetchRequestContext = &RBQArrayFetchRequestContext;
 
 #pragma mark - Public Instance
 
+- (nonnull id)initWithFetchRequest:(nonnull RBQFetchRequest *)fetchRequest
+                sectionNameKeyPath:(nullable NSString *)sectionNameKeyPath
+                         cacheName:(nullable NSString *)name
+{
+    return [self initWithFetchRequest:fetchRequest sectionNameKeyPath:sectionNameKeyPath sectionNameKeyType:RLMPropertyTypeString cacheName:name];
+}
+
 - (id)initWithFetchRequest:(nonnull RBQFetchRequest *)fetchRequest
                 sectionNameKeyPath:(nullable NSString *)sectionNameKeyPath
                 sectionNameKeyType:(RLMPropertyType)sectionNameKeyType
@@ -373,6 +380,7 @@ static void * RBQArrayFetchRequestContext = &RBQArrayFetchRequestContext;
         _cacheName = name;
         _fetchRequest = fetchRequest;
         _sectionNameKeyPath = sectionNameKeyPath;
+        NSAssert(sectionNameKeyType == RLMPropertyTypeString || sectionNameKeyType == RLMPropertyTypeDate || sectionNameKeyType == RLMPropertyTypeInt, @"not support type");
         _sectionNameKeyType = sectionNameKeyType;
 #ifdef DEBUG
 		_logging = true;
@@ -558,6 +566,22 @@ static void * RBQArrayFetchRequestContext = &RBQArrayFetchRequestContext;
     return 0;
 }
 
+- (NSString *)titleForHeaderInSection:(NSInteger)section
+{
+    RBQControllerCacheObject *cache = [self cache];
+    
+    if (cache) {
+        
+        if (section < cache.sections.count) {
+            RBQSectionCacheObject *sectionInfo = cache.sections[section];
+            
+            return sectionInfo.name;
+        }
+    }
+    
+    return @"";
+}
+
 - (id)objectForHeaderInSection:(NSInteger)section
 {
     RBQControllerCacheObject *cache = [self cache];
@@ -571,7 +595,7 @@ static void * RBQArrayFetchRequestContext = &RBQArrayFetchRequestContext;
         }
     }
     
-    return @"";
+    return nil;
 }
 
 - (NSUInteger)sectionIndexForSectionName:(NSString *)sectionName

--- a/RBQFetchedResultsController/Source/RBQFetchedResultsController.m
+++ b/RBQFetchedResultsController/Source/RBQFetchedResultsController.m
@@ -43,21 +43,21 @@ static void * RBQArrayFetchRequestContext = &RBQArrayFetchRequestContext;
 @property (strong, nonatomic) NSString *sectionNameKeyPath;
 
 // Create a RBQFetchedResultsSectionInfo
-+ (instancetype)createSectionWithName:(NSString *)sectionName
++ (instancetype)createSectionWithName:(id)sectionValue
                    sectionNameKeyPath:(NSString *)sectionNameKeyPath
                          fetchRequest:(RBQFetchRequest *)fetchRequest;
 
 @end
 
 @implementation RBQFetchedResultsSectionInfo
-@synthesize name = _name;
+@synthesize value = _value;
 
-+ (instancetype)createSectionWithName:(NSString *)sectionName
++ (instancetype)createSectionWithName:(id)sectionValue
                    sectionNameKeyPath:(NSString *)sectionNameKeyPath
                          fetchRequest:(RBQFetchRequest *)fetchRequest
 {
     RBQFetchedResultsSectionInfo *sectionInfo = [[RBQFetchedResultsSectionInfo alloc] init];
-    sectionInfo->_name = sectionName;
+    sectionInfo->_value = sectionValue;
     sectionInfo.sectionNameKeyPath = sectionNameKeyPath;
     sectionInfo.fetchRequest = fetchRequest;
     
@@ -70,7 +70,7 @@ static void * RBQArrayFetchRequestContext = &RBQArrayFetchRequestContext;
         
         id<RLMCollection> fetchResults = [self.fetchRequest fetchObjects];
         
-        return [fetchResults objectsWhere:@"%K == %@", self.sectionNameKeyPath, self.name];
+        return [fetchResults objectsWhere:@"%K == %@", self.sectionNameKeyPath, self.value];
     }
     else if (self.fetchRequest) {
         return [self.fetchRequest fetchObjects];
@@ -362,9 +362,10 @@ static void * RBQArrayFetchRequestContext = &RBQArrayFetchRequestContext;
 
 #pragma mark - Public Instance
 
-- (id)initWithFetchRequest:(RBQFetchRequest *)fetchRequest
-        sectionNameKeyPath:(NSString *)sectionNameKeyPath
-                 cacheName:(NSString *)name
+- (id)initWithFetchRequest:(nonnull RBQFetchRequest *)fetchRequest
+                sectionNameKeyPath:(nullable NSString *)sectionNameKeyPath
+                sectionNameKeyType:(RLMPropertyType)sectionNameKeyType
+                         cacheName:(nullable NSString *)name
 {
     self = [super init];
     
@@ -372,7 +373,7 @@ static void * RBQArrayFetchRequestContext = &RBQArrayFetchRequestContext;
         _cacheName = name;
         _fetchRequest = fetchRequest;
         _sectionNameKeyPath = sectionNameKeyPath;
-		
+        _sectionNameKeyType = sectionNameKeyType;
 #ifdef DEBUG
 		_logging = true;
 #endif
@@ -393,13 +394,15 @@ static void * RBQArrayFetchRequestContext = &RBQArrayFetchRequestContext;
             [self createCacheWithRealm:[self cacheRealm]
                              cacheName:self.cacheName
                        forFetchRequest:self.fetchRequest
-                    sectionNameKeyPath:self.sectionNameKeyPath];
+                    sectionNameKeyPath:self.sectionNameKeyPath
+                    sectionNameKeyType:self.sectionNameKeyType];
         }
         else {
             [self createCacheWithRealm:[self cacheRealm]
                              cacheName:[self nameForFetchRequest:self.fetchRequest]
                        forFetchRequest:self.fetchRequest
-                    sectionNameKeyPath:self.sectionNameKeyPath];
+                    sectionNameKeyPath:self.sectionNameKeyPath
+                    sectionNameKeyType:self.sectionNameKeyType];
         }
         
         // Only register for changes after the cache was created!
@@ -555,7 +558,7 @@ static void * RBQArrayFetchRequestContext = &RBQArrayFetchRequestContext;
     return 0;
 }
 
-- (NSString *)titleForHeaderInSection:(NSInteger)section
+- (id)objectForHeaderInSection:(NSInteger)section
 {
     RBQControllerCacheObject *cache = [self cache];
     
@@ -564,7 +567,7 @@ static void * RBQArrayFetchRequestContext = &RBQArrayFetchRequestContext;
         if (section < cache.sections.count) {
             RBQSectionCacheObject *sectionInfo = cache.sections[section];
             
-            return sectionInfo.name;
+            return sectionInfo.value;
         }
     }
     
@@ -962,6 +965,7 @@ static void * RBQArrayFetchRequestContext = &RBQArrayFetchRequestContext;
                    cacheName:(NSString *)cacheName
              forFetchRequest:(RBQFetchRequest *)fetchRequest
           sectionNameKeyPath:(NSString *)sectionNameKeyPath
+          sectionNameKeyType:(RLMPropertyType)sectionNameKeyType
 {
     id<RLMCollection> fetchResults = [fetchRequest fetchObjects];
     
@@ -1001,7 +1005,7 @@ static void * RBQArrayFetchRequestContext = &RBQArrayFetchRequestContext;
             
             currentSectionTitle = @"";
             
-            section = [RBQSectionCacheObject cacheWithName:currentSectionTitle];
+            section = [RBQSectionCacheObject cacheWithName:currentSectionTitle keyType:sectionNameKeyType];
             
             section.firstObjectIndex = 0;
         }
@@ -1013,10 +1017,12 @@ static void * RBQArrayFetchRequestContext = &RBQArrayFetchRequestContext;
             if (sectionNameKeyPath) {
                 
                 // Check your sectionNameKeyPath if a crash occurs...
-                NSString *sectionTitle = [object valueForKeyPath:sectionNameKeyPath];
+                id sectionObject = [object valueForKeyPath:sectionNameKeyPath];
+                
+                NSString *sectionTitle = [self getStringForSectionKeyValue:sectionObject sectionNameKeyType:sectionNameKeyType];
                 
                 // New Section Found --> Process It
-                if (![sectionTitle isEqualToString:currentSectionTitle]) {
+                if (![sectionTitle isEqual:currentSectionTitle]) {
                     
                     // If we already gathered up the section objects, then save them
                     if (section.objects.count > 0) {
@@ -1034,7 +1040,7 @@ static void * RBQArrayFetchRequestContext = &RBQArrayFetchRequestContext;
                     currentSectionTitle = sectionTitle;
                     
                     // Reset the section object array
-                    section = [RBQSectionCacheObject cacheWithName:currentSectionTitle];
+                    section = [RBQSectionCacheObject cacheWithName:currentSectionTitle keyType:sectionNameKeyType];
                     
                     section.firstObjectIndex = count;
                 }
@@ -1077,6 +1083,29 @@ static void * RBQArrayFetchRequestContext = &RBQArrayFetchRequestContext;
     }
     
     [cacheRealm commitWriteTransaction];
+}
+
+- (NSString *)getStringForSectionKeyValue:(id)sectionObject sectionNameKeyType:(RLMPropertyType)sectionNameKeyType
+{
+    NSString *sectionTitle;
+    if (sectionNameKeyType == RLMPropertyTypeString) {
+        sectionTitle = (NSString *)sectionObject;
+    }
+    else if (sectionNameKeyType == RLMPropertyTypeInt) {
+        sectionTitle = ((NSNumber *)sectionObject).stringValue;
+    }
+    else if (sectionNameKeyType == RLMPropertyTypeDate) {
+        NSString *dateString = [NSDateFormatter localizedStringFromDate:(NSDate *)sectionObject
+                                                              dateStyle:NSDateFormatterMediumStyle
+                                                              timeStyle:NSDateFormatterFullStyle];
+        sectionTitle = dateString;
+    }
+    else {
+        @throw([NSException exceptionWithName:@"Unsupported primary key type"
+                                       reason:@"RBQFetchedResultsController only supports NSString or int/NSInteger primary keys"
+                                     userInfo:nil]);
+    }
+    return sectionTitle;
 }
 
 #pragma mark - RBQStateObject
@@ -1148,30 +1177,33 @@ static void * RBQArrayFetchRequestContext = &RBQArrayFetchRequestContext;
                     continue;
                 }
             
-            NSString *sectionTitle = nil;
+            id sectionValue = nil;
             
             if (object &&
                 self.sectionNameKeyPath) {
-                sectionTitle = [object valueForKeyPath:self.sectionNameKeyPath];
+                sectionValue = [object valueForKeyPath:self.sectionNameKeyPath];
             }
             else if (self.sectionNameKeyPath) {
                 RBQObjectCacheObject *oldCacheObject =
                 [RBQObjectCacheObject objectInRealm:state.cacheRealm
                                       forPrimaryKey:primaryKeyStringValue];
                 
-                sectionTitle = oldCacheObject.section.name;
+                sectionValue = oldCacheObject.section.value;
             }
             // We aren't using sections so create a dummy one with no text
             else {
-                sectionTitle = @"";
+                sectionValue = @"";
             }
-            
-            if (sectionTitle) {
+             NSString *sectionTitle = [self getStringForSectionKeyValue:sectionValue sectionNameKeyType:self.sectionNameKeyType];
+            if (sectionValue) {
+               
+                
                 RBQSectionCacheObject *section = [RBQSectionCacheObject objectInRealm:state.cacheRealm
                                                                         forPrimaryKey:sectionTitle];
                 
                 if (!section) {
-                    section = [RBQSectionCacheObject cacheWithName:sectionTitle];
+                   
+                    section = [RBQSectionCacheObject cacheWithName:sectionTitle keyType:self.sectionNameKeyType];
                 }
                 
                 [cacheSectionsInChangeSet addObject:section];
@@ -1241,7 +1273,7 @@ static void * RBQArrayFetchRequestContext = &RBQArrayFetchRequestContext;
         if (self.sectionNameKeyPath) {
             sectionResults = [state.fetchResults objectsWhere:@"%K == %@",
                               self.sectionNameKeyPath,
-                              section.name];
+                              section.value];
         }
         // We aren't using sections, so just use all results
         else {
@@ -1441,7 +1473,7 @@ static void * RBQArrayFetchRequestContext = &RBQArrayFetchRequestContext;
         NSInteger oldSectionIndex = [sectionChanges.oldCacheSections indexOfObject:section];
         
         RBQFetchedResultsSectionInfo *sectionInfo =
-        [RBQFetchedResultsSectionInfo createSectionWithName:section.name
+        [RBQFetchedResultsSectionInfo createSectionWithName:section.value
                                          sectionNameKeyPath:self.sectionNameKeyPath
                                                fetchRequest:self.fetchRequest];
         
@@ -1470,7 +1502,7 @@ static void * RBQArrayFetchRequestContext = &RBQArrayFetchRequestContext;
         NSInteger newSectionIndex = [sectionChanges.sortedNewCacheSections indexOfObject:section];
         
         RBQFetchedResultsSectionInfo *sectionInfo =
-        [RBQFetchedResultsSectionInfo createSectionWithName:section.name
+        [RBQFetchedResultsSectionInfo createSectionWithName:section.value
                                          sectionNameKeyPath:self.sectionNameKeyPath
                                                fetchRequest:self.fetchRequest];
         


### PR DESCRIPTION
some times, we will use some property for section(such as NSDate, which support by realm from v1.0) , so I extended this to RBQFetchedResultsController.To use it, people should pass sectionNameKeyType, currently support Int,String,NSDate 